### PR TITLE
Feat/23-search : 검색 API 연동 및 검색 화면 구현

### DIFF
--- a/src/app/navigation/RootNavigator.js
+++ b/src/app/navigation/RootNavigator.js
@@ -4,6 +4,7 @@ import MainTabNavigator from "./MainTabNavigator";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import SplashScreen from "@app/SplashScreen";
 import CommunityStack from "./CommunityStack";
+import SearchScreen from "@features/search/screens/SearchScreen";
 import { bootstrapSession } from "../../shared/services/sessionBootstrap";
 
 const Stack = createNativeStackNavigator();
@@ -59,6 +60,11 @@ const RootNavigator = () => {
         initialParams={authInitialParams}
       />
       <Stack.Screen name="Community" component={CommunityStack} />
+      <Stack.Screen
+        name="Search"
+        component={SearchScreen}
+        options={{ animation: "slide_from_right" }}
+      />
     </Stack.Navigator>
   );
 };

--- a/src/features/home/screens/Home/HomeScreen.jsx
+++ b/src/features/home/screens/Home/HomeScreen.jsx
@@ -54,7 +54,10 @@ const HomeScreen = () => {
 
           <View style={styles.btnContainer}>
             {/* 검색 페이지 navigation 연결! */}
-            <TouchableOpacity style={styles.iconBtn} onPress={() => {}}>
+            <TouchableOpacity
+              style={styles.iconBtn}
+              onPress={() => navigation.navigate("Search")}
+            >
               <SearchIcon width={24} height={24} />
             </TouchableOpacity>
 

--- a/src/features/search/components/RecentSearchSection.jsx
+++ b/src/features/search/components/RecentSearchSection.jsx
@@ -1,0 +1,124 @@
+import React from "react";
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import CommunityLoadingSpinner from "@shared/components/CommunityLoadingSpinner";
+
+const RecentSearchSection = ({
+  logs,
+  isLoading,
+  isError,
+  errorMessage,
+  onDeletePress,
+  onKeywordPress,
+  onRetryPress,
+}) => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>최근 검색어</Text>
+
+      {isLoading ? (
+        <View style={styles.feedbackContainer}>
+          <CommunityLoadingSpinner size={40} />
+        </View>
+      ) : null}
+
+      {!isLoading && isError ? (
+        <View style={styles.feedbackContainer}>
+          <Text style={styles.feedbackText}>{errorMessage}</Text>
+          <TouchableOpacity onPress={onRetryPress}>
+            <Text style={styles.retryText}>다시 시도</Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
+
+      {!isLoading && !isError && logs.length === 0 ? (
+        <View style={styles.feedbackContainer}>
+          <Text style={styles.feedbackText}>최근 검색 내역이 없습니다.</Text>
+        </View>
+      ) : null}
+
+      {!isLoading && !isError && logs.length > 0
+        ? logs.map((log) => (
+            <View key={log.id} style={styles.row}>
+              <TouchableOpacity
+                activeOpacity={0.8}
+                onPress={() => onKeywordPress(log.keyword)}
+                style={styles.keywordButton}
+              >
+                <Text style={styles.keywordText}>{log.keyword}</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                activeOpacity={0.75}
+                onPress={() => onDeletePress(log.id)}
+                style={styles.deleteButton}
+              >
+                <Text style={styles.deleteText}>×</Text>
+              </TouchableOpacity>
+            </View>
+          ))
+        : null}
+    </View>
+  );
+};
+
+export default RecentSearchSection;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 20,
+    paddingTop: 12,
+  },
+  title: {
+    color: "#FFFFFF",
+    fontSize: 29,
+    fontFamily: "NotoSansKR_SemiBold",
+    marginBottom: 20,
+  },
+  row: {
+    minHeight: 48,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  keywordButton: {
+    flex: 1,
+    paddingVertical: 13,
+  },
+  keywordText: {
+    color: "#D5D5D8",
+    fontSize: 16,
+    fontFamily: "NotoSansKR_Regular",
+  },
+  deleteButton: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  deleteText: {
+    color: "#7A7A80",
+    fontSize: 20,
+    lineHeight: 20,
+  },
+  feedbackContainer: {
+    paddingTop: 56,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+  },
+  feedbackText: {
+    color: "#6E6E73",
+    fontSize: 15,
+    fontFamily: "NotoSansKR_Regular",
+    textAlign: "center",
+  },
+  retryText: {
+    color: "#FFFFFF",
+    fontSize: 14,
+    fontFamily: "NotoSansKR_Medium",
+  },
+});

--- a/src/features/search/components/SearchHashtagListItem.jsx
+++ b/src/features/search/components/SearchHashtagListItem.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+
+const SearchHashtagListItem = ({ hashtag, onPress }) => {
+  return (
+    <TouchableOpacity
+      activeOpacity={0.82}
+      disabled={!onPress}
+      onPress={() => onPress?.(hashtag)}
+      style={styles.container}
+    >
+      <View style={styles.iconCircle}>
+        <Text style={styles.iconText}>#</Text>
+      </View>
+
+      <View style={styles.textBlock}>
+        <Text style={styles.tagName}>#{hashtag.tagName}</Text>
+        <Text style={styles.metaText}>{hashtag.usageCount}개</Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default SearchHashtagListItem;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+  },
+  iconCircle: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "#202024",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconText: {
+    color: "#FFFFFF",
+    fontSize: 18,
+    fontFamily: "NotoSansKR_SemiBold",
+  },
+  textBlock: {
+    flex: 1,
+    gap: 4,
+  },
+  tagName: {
+    color: "#FFFFFF",
+    fontSize: 15,
+    fontFamily: "NotoSansKR_SemiBold",
+  },
+  metaText: {
+    color: "#97979E",
+    fontSize: 13,
+    fontFamily: "NotoSansKR_Regular",
+  },
+});

--- a/src/features/search/components/SearchInputHeader.jsx
+++ b/src/features/search/components/SearchInputHeader.jsx
@@ -1,0 +1,111 @@
+import React from "react";
+import {
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import BackIcon from "@shared/assets/svg/chevrons/back.svg";
+import SearchIcon from "@features/community/assets/svg/TopBar/searchIcon.svg";
+
+const SearchInputHeader = ({
+  value,
+  autoFocus = true,
+  onBackPress,
+  onChangeText,
+  onClearPress,
+  onSubmitEditing,
+}) => {
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        activeOpacity={0.75}
+        onPress={onBackPress}
+        style={styles.backButton}
+      >
+        <BackIcon width={12} height={21} />
+      </TouchableOpacity>
+
+      <View style={styles.searchBar}>
+        <SearchIcon width={18} height={18} />
+        <TextInput
+          autoCapitalize="none"
+          autoCorrect={false}
+          autoFocus={autoFocus}
+          onChangeText={onChangeText}
+          onSubmitEditing={onSubmitEditing}
+          placeholder="검색어 입력하기"
+          placeholderTextColor="#7A7A80"
+          returnKeyType="search"
+          selectionColor="#FFFFFF"
+          style={styles.input}
+          value={value}
+        />
+
+        {value?.length > 0 ? (
+          <TouchableOpacity
+            activeOpacity={0.75}
+            onPress={onClearPress}
+            style={styles.clearButton}
+          >
+            <Text style={styles.clearButtonText}>×</Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+    </View>
+  );
+};
+
+export default SearchInputHeader;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 18,
+    backgroundColor: "#09090A",
+  },
+  backButton: {
+    width: 24,
+    height: 24,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  searchBar: {
+    flex: 1,
+    height: 44,
+    borderRadius: 14,
+    backgroundColor: "#2C2C2F",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingLeft: 14,
+    paddingRight: 10,
+  },
+  input: {
+    flex: 1,
+    color: "#FFFFFF",
+    fontSize: 15,
+    fontFamily: "NotoSansKR_Medium",
+    paddingVertical: 0,
+  },
+  clearButton: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: "#D7D7DA",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  clearButtonText: {
+    color: "#2C2C2F",
+    fontSize: 16,
+    lineHeight: 16,
+    fontWeight: "700",
+    marginTop: -1,
+  },
+});

--- a/src/features/search/components/SearchPostCard.jsx
+++ b/src/features/search/components/SearchPostCard.jsx
@@ -1,0 +1,262 @@
+import React, { useEffect, useState } from "react";
+import {
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import PostReactions from "@features/community/component/PostReactions";
+import CommunityUserProfile from "@features/community/component/CommunityUserProfile";
+import { useTogglePostEmotionMutation } from "@features/community/services/emotionMutations";
+import { useUserEmotionSelection } from "@features/community/store/userEmotionSelectionStore";
+import { AppText } from "@shared/theme/components/AppText";
+
+const renderHighlightedSnippet = (snippet) => {
+  if (!snippet) {
+    return null;
+  }
+
+  return snippet
+    .split(/(<em>.*?<\/em>)/g)
+    .filter(Boolean)
+    .map((segment, index) => {
+      const isHighlighted =
+        segment.startsWith("<em>") && segment.endsWith("</em>");
+      const text = segment.replace(/<\/?em>/g, "");
+
+      return (
+        <Text
+          key={`${text}-${index}`}
+          style={isHighlighted ? styles.highlightText : styles.snippetText}
+        >
+          {text}
+        </Text>
+      );
+    });
+};
+
+const SearchPostCard = ({ post }) => {
+  const navigation = useNavigation();
+  const [localEmotions, setLocalEmotions] = useState(post?.emotions ?? {});
+  const selectedEmotionFromStore = useUserEmotionSelection(post?.postId);
+  const selectedEmotionType =
+    selectedEmotionFromStore ?? (post?.hasLiked ? "LIKE" : null);
+  const toggleEmotionMutation = useTogglePostEmotionMutation(post?.postId, {
+    onSuccess: (data) => {
+      if (data?.emotions) {
+        setLocalEmotions(data.emotions);
+      }
+    },
+  });
+  const imageUrls = post.imageUrls ?? [];
+  const hashtagText =
+    post.hashtags?.length > 0
+      ? post.hashtags.map((tag) => `#${tag}`).join(" ")
+      : null;
+
+  useEffect(() => {
+    setLocalEmotions(post?.emotions ?? {});
+  }, [post?.postId, post?.emotions]);
+
+  const handlePressPost = () => {
+    if (!post?.postId) {
+      return;
+    }
+
+    navigation.navigate("Community", {
+      screen: "PostDetail",
+      params: { postId: post.postId },
+    });
+  };
+
+  const handlePressProfile = () => {
+    if (!post?.author?.userId) {
+      return;
+    }
+
+    navigation.navigate("Main", {
+      screen: "Profile",
+      params: {
+        screen: "ProfileMain",
+        params: { userId: post.author.userId },
+      },
+    });
+  };
+
+  const reactionPost = {
+    ...post,
+    id: post.postId,
+    comments: post.commentCount,
+    reactionCounts: {
+      LIKE: localEmotions?.likeCount ?? 0,
+      SAD: localEmotions?.sadCount ?? 0,
+      FUN: localEmotions?.funCount ?? 0,
+      HYPE: localEmotions?.hypeCount ?? 0,
+    },
+    emotions: localEmotions,
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <View style={styles.authorRow}>
+          <CommunityUserProfile
+            createdAt={post.createdAt}
+            nickname={post.author?.nickname}
+            onPress={handlePressProfile}
+            showTeam
+            teamCode={post.author?.teamCode}
+          />
+        </View>
+
+        <TouchableOpacity
+          activeOpacity={0.82}
+          onPress={handlePressPost}
+          style={styles.bodyPressable}
+        >
+          <View style={styles.contentSection}>
+            <Text numberOfLines={4} style={styles.snippetWrapper}>
+              {renderHighlightedSnippet(post.snippet)}
+            </Text>
+
+            {hashtagText ? (
+              <AppText
+                numberOfLines={2}
+                variant="caption"
+                style={styles.hashText}
+              >
+                {hashtagText}
+              </AppText>
+            ) : null}
+          </View>
+        </TouchableOpacity>
+
+        {imageUrls.length === 1 ? (
+          <TouchableOpacity
+            activeOpacity={0.82}
+            onPress={handlePressPost}
+            style={styles.imagePressable}
+          >
+            <Image source={{ uri: imageUrls[0] }} style={styles.singleImage} />
+          </TouchableOpacity>
+        ) : null}
+
+        {imageUrls.length > 1 ? (
+          <ScrollView
+            contentContainerStyle={styles.galleryContent}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+          >
+            {imageUrls.map((imageUrl, index) => (
+              <TouchableOpacity
+                activeOpacity={0.82}
+                key={`${post.postId}-${index}`}
+                onPress={handlePressPost}
+              >
+                <Image source={{ uri: imageUrl }} style={styles.galleryImage} />
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        ) : null}
+
+        <PostReactions
+          isEmotionPending={toggleEmotionMutation.isPending}
+          onCommentPress={handlePressPost}
+          onSelectReaction={(_postId, reaction) => {
+            if (!reaction?.id) {
+              return;
+            }
+
+            toggleEmotionMutation.mutate({
+              emotionType: reaction.id,
+            });
+          }}
+          onToggleEmotion={(_postId, emotionType) => {
+            if (!emotionType) {
+              return;
+            }
+
+            toggleEmotionMutation.mutate({
+              emotionType,
+            });
+          }}
+          post={reactionPost}
+          selectedEmotionType={selectedEmotionType}
+        />
+      </View>
+    </View>
+  );
+};
+
+export default SearchPostCard;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 17,
+    paddingVertical: 5,
+  },
+  card: {
+    backgroundColor: "rgba(63, 63, 63, 0.30)",
+    borderRadius: 5,
+    borderColor: "rgba(127, 127, 127, 0.28)",
+    borderWidth: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 13,
+  },
+  authorRow: {
+    marginBottom: 4,
+  },
+  bodyPressable: {
+    flex: 1,
+  },
+  contentSection: {
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+  },
+  snippetWrapper: {
+    color: "#F9F9F9",
+    lineHeight: 20,
+  },
+  snippetText: {
+    color: "#F9F9F9",
+    fontSize: 14,
+    lineHeight: 20,
+    fontFamily: "NotoSansKR_Regular",
+  },
+  highlightText: {
+    color: "#FFFFFF",
+    backgroundColor: "#6E1833",
+    fontSize: 14,
+    lineHeight: 20,
+    fontFamily: "NotoSansKR_SemiBold",
+  },
+  hashText: {
+    color: "#6F9D48",
+    lineHeight: 19,
+    marginTop: 6,
+  },
+  singleImage: {
+    width: "100%",
+    height: 200,
+    borderRadius: 10,
+    backgroundColor: "#1D1D21",
+  },
+  imagePressable: {
+    marginTop: 10,
+  },
+  galleryContent: {
+    gap: 8,
+    paddingTop: 10,
+    paddingRight: 20,
+    paddingHorizontal: 5,
+  },
+  galleryImage: {
+    width: 164,
+    height: 164,
+    borderRadius: 10,
+    backgroundColor: "#1D1D21",
+  },
+});

--- a/src/features/search/components/SearchResultTabs.jsx
+++ b/src/features/search/components/SearchResultTabs.jsx
@@ -1,0 +1,282 @@
+import React, { useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import DropDownIcon from "@features/community/assets/svg/CommunityPost/dropDown.svg";
+
+const RESULT_TABS = [
+  { key: "posts", label: "게시글" },
+  { key: "users", label: "계정" },
+  { key: "hashtags", label: "태그" },
+];
+
+const POST_CHANNELS = [
+  { key: "ALL", label: "전체" },
+  { key: "TEAM", label: "내 팀" },
+];
+
+const POST_SORTS = [
+  { key: "RECOMMENDED", label: "추천순" },
+  { key: "POPULAR", label: "인기순" },
+  { key: "LATEST", label: "최신순" },
+];
+
+const SearchResultTabs = ({
+  activeTab,
+  activePostChannel,
+  activePostSort,
+  onTabChange,
+  onPostChannelChange,
+  onPostSortChange,
+}) => {
+  const [isSortMenuOpen, setIsSortMenuOpen] = useState(false);
+  const activeSortLabel =
+    POST_SORTS.find((sort) => sort.key === activePostSort)?.label ?? "추천순";
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.tabRow}>
+        {RESULT_TABS.map((tab) => {
+          const isActive = activeTab === tab.key;
+
+          return (
+            <TouchableOpacity
+              activeOpacity={0.86}
+              key={tab.key}
+              onPress={() => onTabChange(tab.key)}
+              style={styles.tabButton}
+            >
+              <Text style={[styles.tabLabel, isActive && styles.activeTabLabel]}>
+                {tab.label}
+              </Text>
+              <View
+                style={[
+                  styles.tabIndicator,
+                  isActive && styles.activeTabIndicator,
+                ]}
+              />
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {activeTab === "posts" ? (
+        <View style={styles.postsFilterSection}>
+          <View style={styles.filterRow}>
+            <View style={styles.channelRow}>
+              {POST_CHANNELS.map((channel) => {
+                const isActive = activePostChannel === channel.key;
+
+                return (
+                  <TouchableOpacity
+                    activeOpacity={0.86}
+                    key={channel.key}
+                    onPress={() => onPostChannelChange(channel.key)}
+                    style={[
+                      styles.channelButton,
+                      isActive && styles.activeChannelButton,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.channelLabel,
+                        isActive && styles.activeChannelLabel,
+                      ]}
+                    >
+                      {channel.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            <View style={styles.sortBoxWrap}>
+              <TouchableOpacity
+                activeOpacity={0.86}
+                onPress={() => setIsSortMenuOpen((prev) => !prev)}
+                style={[
+                  styles.sortSelectButton,
+                  isSortMenuOpen && styles.sortSelectButtonOpen,
+                ]}
+              >
+                <Text style={styles.sortSelectLabel}>{activeSortLabel}</Text>
+                <View
+                  style={[
+                    styles.sortIconWrap,
+                    isSortMenuOpen && styles.sortIconWrapOpen,
+                  ]}
+                >
+                  <DropDownIcon width={12} height={8} />
+                </View>
+              </TouchableOpacity>
+
+              {isSortMenuOpen ? (
+                <View style={styles.sortMenu}>
+                  {POST_SORTS.map((sort, index) => {
+                    const isActive = activePostSort === sort.key;
+
+                    return (
+                      <TouchableOpacity
+                        activeOpacity={0.86}
+                        key={sort.key}
+                        onPress={() => {
+                          onPostSortChange(sort.key);
+                          setIsSortMenuOpen(false);
+                        }}
+                        style={[
+                          styles.sortMenuItem,
+                          index < POST_SORTS.length - 1 && styles.sortMenuDivider,
+                        ]}
+                      >
+                        <Text
+                          style={[
+                            styles.sortMenuLabel,
+                            isActive && styles.activeSortMenuLabel,
+                          ]}
+                        >
+                          {sort.label}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              ) : null}
+            </View>
+          </View>
+        </View>
+      ) : null}
+    </View>
+  );
+};
+
+export default SearchResultTabs;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: 6,
+    paddingBottom: 10,
+    backgroundColor: "#09090A",
+    gap: 14,
+  },
+  tabRow: {
+    flexDirection: "row",
+    borderBottomWidth: 1,
+    borderBottomColor: "#1F2230",
+  },
+  tabButton: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: 14,
+    paddingTop: 6,
+  },
+  tabLabel: {
+    color: "#8F95A7",
+    fontSize: 15,
+    fontFamily: "NotoSansKR_Medium",
+  },
+  activeTabLabel: {
+    color: "#F6F7FB",
+  },
+  tabIndicator: {
+    width: "100%",
+    height: 3,
+    backgroundColor: "transparent",
+    borderRadius: 999,
+  },
+  activeTabIndicator: {
+    backgroundColor: "#EE4F4F",
+  },
+  postsFilterSection: {
+    paddingHorizontal: 20,
+    zIndex: 20,
+  },
+  filterRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  channelButton: {
+    minWidth: 74,
+    minHeight: 38,
+    borderRadius: 999,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 18,
+    paddingVertical: 8,
+  },
+  activeChannelButton: {
+    backgroundColor: "#FFFFFF",
+  },
+  channelLabel: {
+    color: "#8B90A1",
+    fontSize: 14,
+    fontFamily: "NotoSansKR_Medium",
+  },
+  activeChannelLabel: {
+    color: "#11141C",
+  },
+  channelRow: {
+    flexDirection: "row",
+    gap: 6,
+    borderRadius: 999,
+    backgroundColor: "#161C2E",
+    padding: 4,
+  },
+  sortBoxWrap: {
+    position: "relative",
+    width: 102,
+    zIndex: 30,
+  },
+  sortSelectButton: {
+    minHeight: 38,
+    borderRadius: 12,
+    backgroundColor: "#161C2E",
+    borderWidth: 1,
+    borderColor: "#242B43",
+    paddingHorizontal: 11,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  sortSelectButtonOpen: {
+    borderColor: "#39425F",
+  },
+  sortSelectLabel: {
+    color: "#F5F6FA",
+    fontSize: 12,
+    fontFamily: "NotoSansKR_Medium",
+  },
+  sortIconWrap: {
+    opacity: 0.7,
+  },
+  sortIconWrapOpen: {
+    transform: [{ rotate: "180deg" }],
+  },
+  sortMenu: {
+    position: "absolute",
+    top: 42,
+    left: 0,
+    right: 0,
+    borderRadius: 12,
+    backgroundColor: "#161C2E",
+    borderWidth: 1,
+    borderColor: "#242B43",
+    overflow: "hidden",
+  },
+  sortMenuItem: {
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+  },
+  sortMenuDivider: {
+    borderBottomWidth: 1,
+    borderBottomColor: "#242B43",
+  },
+  sortMenuLabel: {
+    color: "#B1B7C8",
+    fontSize: 13,
+    fontFamily: "NotoSansKR_Medium",
+  },
+  activeSortMenuLabel: {
+    color: "#FFFFFF",
+  },
+});

--- a/src/features/search/components/SearchSuggestionsSection.jsx
+++ b/src/features/search/components/SearchSuggestionsSection.jsx
@@ -1,0 +1,126 @@
+import React from "react";
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import CommunityLoadingSpinner from "@shared/components/CommunityLoadingSpinner";
+import SearchUserRow from "./SearchUserRow";
+
+const SearchSuggestionsSection = ({
+  suggestions,
+  isLoading,
+  isError,
+  errorMessage,
+  onRetryPress,
+  onKeywordPress,
+  onUserPress,
+}) => {
+  const hasKeywords = (suggestions?.suggestedKeywords?.length ?? 0) > 0;
+  const hasUsers = (suggestions?.suggestedUsers?.length ?? 0) > 0;
+  const hasContent = hasKeywords || hasUsers;
+
+  return (
+    <View style={styles.container}>
+      {isLoading ? (
+        <View style={styles.feedbackContainer}>
+          <CommunityLoadingSpinner size={40} />
+        </View>
+      ) : null}
+
+      {!isLoading && isError ? (
+        <View style={styles.feedbackContainer}>
+          <Text style={styles.feedbackText}>{errorMessage}</Text>
+          <TouchableOpacity onPress={onRetryPress}>
+            <Text style={styles.retryText}>다시 시도</Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
+
+      {!isLoading && !isError && !hasContent ? (
+        <View style={styles.feedbackContainer}>
+          <Text style={styles.feedbackText}>추천 결과가 없습니다.</Text>
+        </View>
+      ) : null}
+
+      {!isLoading && !isError && hasKeywords ? (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>추천 검색어</Text>
+          {suggestions.suggestedKeywords.map((keyword) => (
+            <TouchableOpacity
+              activeOpacity={0.82}
+              key={keyword}
+              onPress={() => onKeywordPress(keyword)}
+              style={styles.keywordRow}
+            >
+              <Text style={styles.keywordText}>{keyword}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      ) : null}
+
+      {!isLoading && !isError && hasUsers ? (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>추천 계정</Text>
+          {suggestions.suggestedUsers.map((user) => (
+            <SearchUserRow
+              avatarSize={42}
+              key={user.userId}
+              onPress={onUserPress}
+              style={styles.userRow}
+              user={user}
+            />
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+};
+
+export default SearchSuggestionsSection;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    paddingBottom: 24,
+    gap: 28,
+  },
+  section: {
+    gap: 10,
+  },
+  sectionTitle: {
+    color: "#9E9EA4",
+    fontSize: 13,
+    fontFamily: "NotoSansKR_Medium",
+  },
+  keywordRow: {
+    paddingVertical: 10,
+  },
+  keywordText: {
+    color: "#F1F1F3",
+    fontSize: 16,
+    fontFamily: "NotoSansKR_Regular",
+  },
+  userRow: {
+    paddingVertical: 2,
+  },
+  feedbackContainer: {
+    paddingTop: 56,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+  },
+  feedbackText: {
+    color: "#6E6E73",
+    fontSize: 15,
+    fontFamily: "NotoSansKR_Regular",
+    textAlign: "center",
+  },
+  retryText: {
+    color: "#FFFFFF",
+    fontSize: 14,
+    fontFamily: "NotoSansKR_Medium",
+  },
+});

--- a/src/features/search/components/SearchUserListItem.jsx
+++ b/src/features/search/components/SearchUserListItem.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import SearchUserRow from "./SearchUserRow";
+
+const SearchUserListItem = ({ user }) => {
+  const navigation = useNavigation();
+
+  const handlePress = (selectedUser) => {
+    if (!selectedUser?.userId) {
+      return;
+    }
+
+    navigation.navigate("Main", {
+      screen: "Profile",
+      params: {
+        screen: "ProfileMain",
+        params: { userId: selectedUser.userId },
+      },
+    });
+  };
+
+  return (
+    <View style={styles.container}>
+      <SearchUserRow onPress={handlePress} user={user} />
+    </View>
+  );
+};
+
+export default SearchUserListItem;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 20,
+    paddingVertical: 4,
+  },
+});

--- a/src/features/search/components/SearchUserRow.jsx
+++ b/src/features/search/components/SearchUserRow.jsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { AppText } from "@shared/theme/components/AppText";
+import { TEAM_DATA } from "@shared/constants/teams";
+import TeamLabel from "@features/community/component/communityMain/TeamLabel";
+
+const SearchUserRow = ({
+  user,
+  onPress,
+  showBio = true,
+  avatarSize = 48,
+  style,
+}) => {
+  const team = TEAM_DATA[user?.teamCode];
+  const ProfileIcon = team?.ProfileIcon;
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.82}
+      disabled={!onPress}
+      onPress={() => onPress?.(user)}
+      style={[styles.container, style]}
+    >
+      <LinearGradient
+        colors={team?.gradient?.colors || ["#3A3D44", "#3A3D44"]}
+        locations={team?.gradient?.locations}
+        start={team?.gradient?.start}
+        end={team?.gradient?.end}
+        style={[
+          styles.avatarCircle,
+          {
+            width: avatarSize,
+            height: avatarSize,
+            borderRadius: avatarSize / 2,
+          },
+        ]}
+      >
+        {ProfileIcon ? (
+          <ProfileIcon width={avatarSize * 0.7} height={avatarSize * 0.7} />
+        ) : (
+          <AppText variant="semi16" style={styles.avatarFallback}>
+            {user?.nickname?.[0] ?? "?"}
+          </AppText>
+        )}
+      </LinearGradient>
+
+      <View style={styles.textBlock}>
+        <View style={styles.titleRow}>
+          <AppText variant="caption" style={styles.nickname}>
+            {user?.nickname ?? "알 수 없음"}
+          </AppText>
+          {user?.teamCode ? <TeamLabel teamCode={user.teamCode} /> : null}
+        </View>
+
+        {showBio && user?.bio ? (
+          <AppText numberOfLines={2} variant="middle" style={styles.bio}>
+            {user.bio}
+          </AppText>
+        ) : null}
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default SearchUserRow;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingVertical: 8,
+  },
+  avatarCircle: {
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+  },
+  avatarFallback: {
+    color: "#FFFFFF",
+  },
+  textBlock: {
+    flex: 1,
+    gap: 4,
+  },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    flexWrap: "wrap",
+  },
+  nickname: {
+    color: "#D4D4D4",
+    lineHeight: 19,
+  },
+  bio: {
+    color: "#A1A1AA",
+    lineHeight: 19,
+  },
+});

--- a/src/features/search/hooks/useDebouncedValue.js
+++ b/src/features/search/hooks/useDebouncedValue.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export const useDebouncedValue = (value, delay = 300) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [delay, value]);
+
+  return debouncedValue;
+};
+
+export default useDebouncedValue;

--- a/src/features/search/screens/SearchScreen.jsx
+++ b/src/features/search/screens/SearchScreen.jsx
@@ -1,0 +1,442 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useNavigation } from "@react-navigation/native";
+import { useQueryClient } from "@tanstack/react-query";
+import CommunityLoadingSpinner from "@shared/components/CommunityLoadingSpinner";
+import SearchHashtagListItem from "../components/SearchHashtagListItem";
+import SearchInputHeader from "../components/SearchInputHeader";
+import SearchPostCard from "../components/SearchPostCard";
+import SearchResultTabs from "../components/SearchResultTabs";
+import SearchSuggestionsSection from "../components/SearchSuggestionsSection";
+import SearchUserListItem from "../components/SearchUserListItem";
+import RecentSearchSection from "../components/RecentSearchSection";
+import { useDebouncedValue } from "../hooks/useDebouncedValue";
+import { searchKeys } from "../services/searchKeys";
+import { useDeleteSearchLogMutation } from "../services/useDeleteSearchLogMutation";
+import { useSearchHashtagsInfiniteQuery } from "../services/useSearchHashtagsInfiniteQuery";
+import { useSearchMyLogsQuery } from "../services/useSearchMyLogsQuery";
+import { useSearchPostsInfiniteQuery } from "../services/useSearchPostsInfiniteQuery";
+import { useSearchSuggestionsQuery } from "../services/useSearchSuggestionsQuery";
+import { useSearchUsersInfiniteQuery } from "../services/useSearchUsersInfiniteQuery";
+import { getErrorMessage } from "../utils/formatters";
+import { isPureChoseongQuery } from "../utils/queryGuards";
+
+const flattenPages = (pages, idKey) => {
+  if (!pages?.length) {
+    return [];
+  }
+
+  const mergedItems = pages.flatMap((page) => page.items ?? []);
+
+  if (!idKey) {
+    return mergedItems;
+  }
+
+  const seen = new Set();
+
+  return mergedItems.filter((item) => {
+    const id = item?.[idKey];
+
+    if (id == null) {
+      return true;
+    }
+
+    if (seen.has(id)) {
+      return false;
+    }
+
+    seen.add(id);
+    return true;
+  });
+};
+
+const ResultFeedback = ({ message, actionLabel, onActionPress, loading }) => {
+  return (
+    <View style={styles.resultFeedbackContainer}>
+      {loading ? <CommunityLoadingSpinner size={42} /> : null}
+      <Text style={styles.resultFeedbackText}>{message}</Text>
+      {actionLabel ? (
+        <TouchableOpacity activeOpacity={0.8} onPress={onActionPress}>
+          <Text style={styles.resultFeedbackAction}>{actionLabel}</Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+};
+
+const SearchScreen = () => {
+  const navigation = useNavigation();
+  const queryClient = useQueryClient();
+
+  const [keyword, setKeyword] = useState("");
+  const [submittedKeyword, setSubmittedKeyword] = useState("");
+  const [isResultMode, setIsResultMode] = useState(false);
+  const [activeTab, setActiveTab] = useState("posts");
+  const [postChannel, setPostChannel] = useState("ALL");
+  const [postSort, setPostSort] = useState("RECOMMENDED");
+
+  const trimmedKeyword = keyword.trim();
+  const debouncedKeyword = useDebouncedValue(trimmedKeyword, 300);
+  const isChoseongOnlyKeyword = isPureChoseongQuery(debouncedKeyword);
+
+  const showRecentLogs = trimmedKeyword.length === 0;
+  const showSuggestions =
+    debouncedKeyword.length > 0 &&
+    !isResultMode &&
+    !isChoseongOnlyKeyword;
+  const showResults = trimmedKeyword.length > 0 && isResultMode;
+
+  const recentLogsQuery = useSearchMyLogsQuery({
+    enabled: showRecentLogs,
+  });
+
+  const suggestionsQuery = useSearchSuggestionsQuery({
+    keyword: debouncedKeyword,
+    enabled: showSuggestions,
+  });
+
+  const usersQuery = useSearchUsersInfiniteQuery({
+    keyword: submittedKeyword,
+    enabled: showResults && activeTab === "users",
+  });
+
+  const postsQuery = useSearchPostsInfiniteQuery({
+    keyword: submittedKeyword,
+    channel: postChannel,
+    sort: postSort,
+    enabled: showResults && activeTab === "posts",
+  });
+
+  const hashtagsQuery = useSearchHashtagsInfiniteQuery({
+    keyword: submittedKeyword,
+    enabled: showResults && activeTab === "hashtags",
+  });
+
+  const deleteSearchLogMutation = useDeleteSearchLogMutation();
+
+  const resultQueries = {
+    users: usersQuery,
+    posts: postsQuery,
+    hashtags: hashtagsQuery,
+  };
+
+  const activeResultQuery = resultQueries[activeTab];
+
+  const userItems = useMemo(
+    () => flattenPages(usersQuery.data?.pages, "userId"),
+    [usersQuery.data?.pages],
+  );
+  const postItems = useMemo(
+    () => flattenPages(postsQuery.data?.pages, "postId"),
+    [postsQuery.data?.pages],
+  );
+  const hashtagItems = useMemo(
+    () => flattenPages(hashtagsQuery.data?.pages, "hashtagId"),
+    [hashtagsQuery.data?.pages],
+  );
+
+  useEffect(() => {
+    if (!showResults || !activeResultQuery?.isSuccess) {
+      return;
+    }
+
+    queryClient.invalidateQueries({
+      queryKey: searchKeys.logs(),
+    });
+  }, [
+    activeResultQuery?.dataUpdatedAt,
+    activeResultQuery?.isSuccess,
+    queryClient,
+    showResults,
+  ]);
+
+  const handleBackPress = () => {
+    navigation.goBack();
+  };
+
+  const handleClearPress = () => {
+    setKeyword("");
+    setSubmittedKeyword("");
+    setIsResultMode(false);
+    setActiveTab("posts");
+    setPostChannel("ALL");
+    setPostSort("RECOMMENDED");
+  };
+
+  const handleChangeKeyword = (value) => {
+    setKeyword(value);
+
+    if (isResultMode) {
+      setIsResultMode(false);
+    }
+  };
+
+  const submitSearch = (nextKeyword, options = {}) => {
+    const trimmed = nextKeyword?.trim();
+
+    if (!trimmed) {
+      return;
+    }
+
+    setKeyword(trimmed);
+    setSubmittedKeyword(trimmed);
+    setIsResultMode(true);
+    setActiveTab(options.activeTab ?? "posts");
+    setPostChannel(options.postChannel ?? "ALL");
+    setPostSort(options.postSort ?? "RECOMMENDED");
+  };
+
+  const handleDeleteLog = (logId) => {
+    deleteSearchLogMutation.mutate(logId);
+  };
+
+  const handlePressSuggestedUser = (user) => {
+    if (!user?.userId) {
+      return;
+    }
+
+    navigation.navigate("Main", {
+      screen: "Profile",
+      params: {
+        screen: "ProfileMain",
+        params: { userId: user.userId },
+      },
+    });
+  };
+
+  const handleLoadMore = () => {
+    if (
+      !showResults ||
+      !activeResultQuery?.hasNextPage ||
+      activeResultQuery?.isFetchingNextPage
+    ) {
+      return;
+    }
+
+    activeResultQuery.fetchNextPage();
+  };
+
+  const renderResultListFooter = () => {
+    if (!activeResultQuery?.isFetchingNextPage) {
+      return <View style={styles.listFooterSpacing} />;
+    }
+
+    return (
+      <View style={styles.listFooterLoading}>
+        <CommunityLoadingSpinner size={32} />
+      </View>
+    );
+  };
+
+  const renderResultEmpty = () => {
+    if (activeResultQuery?.isPending) {
+      return (
+        <ResultFeedback
+          loading
+          message="검색 결과를 불러오고 있어요."
+        />
+      );
+    }
+
+    if (activeResultQuery?.isError) {
+      return (
+        <ResultFeedback
+          actionLabel="다시 시도"
+          message={getErrorMessage(
+            activeResultQuery.error,
+            "검색 결과를 불러오지 못했습니다.",
+          )}
+          onActionPress={() => activeResultQuery.refetch()}
+        />
+      );
+    }
+
+    return <ResultFeedback message="검색 결과가 없습니다." />;
+  };
+
+  const renderResults = () => {
+    if (!showResults) {
+      return null;
+    }
+
+    if (activeTab === "users") {
+      return (
+        <FlatList
+          contentContainerStyle={styles.resultListContent}
+          data={userItems}
+          keyboardShouldPersistTaps="handled"
+          keyExtractor={(item) => `${item.userId}`}
+          ListEmptyComponent={renderResultEmpty}
+          ListFooterComponent={renderResultListFooter}
+          onEndReached={handleLoadMore}
+          onEndReachedThreshold={0.4}
+          renderItem={({ item }) => <SearchUserListItem user={item} />}
+          showsVerticalScrollIndicator={false}
+        />
+      );
+    }
+
+    if (activeTab === "posts") {
+      return (
+        <FlatList
+          contentContainerStyle={styles.resultListContent}
+          data={postItems}
+          keyboardShouldPersistTaps="handled"
+          keyExtractor={(item) => `${item.postId}`}
+          ListEmptyComponent={renderResultEmpty}
+          ListFooterComponent={renderResultListFooter}
+          onEndReached={handleLoadMore}
+          onEndReachedThreshold={0.3}
+          renderItem={({ item }) => <SearchPostCard post={item} />}
+          showsVerticalScrollIndicator={false}
+        />
+      );
+    }
+
+    return (
+      <FlatList
+        contentContainerStyle={styles.resultListContent}
+        data={hashtagItems}
+        keyboardShouldPersistTaps="handled"
+        keyExtractor={(item) => `${item.hashtagId}`}
+        ListEmptyComponent={renderResultEmpty}
+        ListFooterComponent={renderResultListFooter}
+        onEndReached={handleLoadMore}
+        onEndReachedThreshold={0.4}
+        renderItem={({ item }) => <SearchHashtagListItem hashtag={item} />}
+        showsVerticalScrollIndicator={false}
+      />
+    );
+  };
+
+  return (
+    <SafeAreaView edges={["top"]} style={styles.safeArea}>
+      <StatusBar barStyle="light-content" />
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={styles.container}
+      >
+        <SearchInputHeader
+          onBackPress={handleBackPress}
+          onChangeText={handleChangeKeyword}
+          onClearPress={handleClearPress}
+          onSubmitEditing={() => submitSearch(keyword)}
+          value={keyword}
+        />
+
+        {showResults ? (
+          <SearchResultTabs
+            activePostChannel={postChannel}
+            activePostSort={postSort}
+            activeTab={activeTab}
+            onPostChannelChange={setPostChannel}
+            onPostSortChange={setPostSort}
+            onTabChange={setActiveTab}
+          />
+        ) : null}
+
+        {showRecentLogs ? (
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <RecentSearchSection
+              errorMessage={getErrorMessage(
+                recentLogsQuery.error,
+                "최근 검색어를 불러오지 못했습니다.",
+              )}
+              isError={recentLogsQuery.isError}
+              isLoading={recentLogsQuery.isPending}
+              logs={recentLogsQuery.data?.logs ?? []}
+              onDeletePress={handleDeleteLog}
+              onKeywordPress={(value) => submitSearch(value)}
+              onRetryPress={() => recentLogsQuery.refetch()}
+            />
+          </ScrollView>
+        ) : null}
+
+        {showSuggestions ? (
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <SearchSuggestionsSection
+              errorMessage={getErrorMessage(
+                suggestionsQuery.error,
+                "추천 결과를 불러오지 못했습니다.",
+              )}
+              isError={suggestionsQuery.isError}
+              isLoading={suggestionsQuery.isPending}
+              onKeywordPress={(value) => submitSearch(value)}
+              onRetryPress={() => suggestionsQuery.refetch()}
+              onUserPress={handlePressSuggestedUser}
+              suggestions={suggestionsQuery.data}
+            />
+          </ScrollView>
+        ) : null}
+
+        {renderResults()}
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+export default SearchScreen;
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: "#09090A",
+  },
+  container: {
+    flex: 1,
+    backgroundColor: "#09090A",
+  },
+  scrollContent: {
+    paddingBottom: 40,
+  },
+  resultListContent: {
+    flexGrow: 1,
+    paddingTop: 6,
+    paddingBottom: 28,
+  },
+  resultFeedbackContainer: {
+    flex: 1,
+    minHeight: 280,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+    paddingHorizontal: 24,
+  },
+  resultFeedbackText: {
+    color: "#76767C",
+    fontSize: 15,
+    fontFamily: "NotoSansKR_Regular",
+    textAlign: "center",
+  },
+  resultFeedbackAction: {
+    color: "#FFFFFF",
+    fontSize: 14,
+    fontFamily: "NotoSansKR_Medium",
+  },
+  listFooterLoading: {
+    paddingVertical: 20,
+  },
+  listFooterSpacing: {
+    height: 20,
+  },
+});

--- a/src/features/search/services/searchApi.js
+++ b/src/features/search/services/searchApi.js
@@ -1,0 +1,112 @@
+import api from "@shared/libs/api";
+
+const SEARCH_BASE_PATH = "/api/v1/search";
+
+const normalizeCursor = (cursor) => {
+  if (!cursor || cursor.score == null || cursor.id == null) {
+    return null;
+  }
+
+  return {
+    score: cursor.score,
+    id: cursor.id,
+  };
+};
+
+const buildCursorParams = (cursor) => {
+  if (!cursor || cursor.score == null || cursor.id == null) {
+    return {};
+  }
+
+  return {
+    cursorScore: cursor.score,
+    cursorId: cursor.id,
+  };
+};
+
+const normalizePagedResponse = (data, itemsKey) => {
+  return {
+    items: data?.[itemsKey] ?? [],
+    hasNext: Boolean(data?.hasNext),
+    nextCursor: normalizeCursor(data?.nextCursor),
+  };
+};
+
+export const fetchMySearchLogs = async () => {
+  try {
+    const { data } = await api.get(`${SEARCH_BASE_PATH}/my-logs`);
+    return {
+      logs: data?.logs ?? [],
+    };
+  } catch (error) {
+    const status = error?.response?.status;
+
+    if (status >= 500) {
+      console.log("search my-logs fallback:", {
+        status,
+        data: error?.response?.data,
+      });
+
+      return {
+        logs: [],
+      };
+    }
+
+    throw error;
+  }
+};
+
+export const deleteMySearchLog = async (logId) => {
+  await api.delete(`${SEARCH_BASE_PATH}/my-logs/${logId}`);
+};
+
+export const fetchSearchSuggestions = async (keyword) => {
+  const { data } = await api.get(`${SEARCH_BASE_PATH}/suggestions`, {
+    params: { keyword },
+  });
+
+  return {
+    suggestedKeywords: data?.suggestedKeywords ?? [],
+    suggestedUsers: data?.suggestedUsers ?? [],
+  };
+};
+
+export const fetchSearchUsersPage = async ({ keyword, cursor }) => {
+  const { data } = await api.get(`${SEARCH_BASE_PATH}/users`, {
+    params: {
+      keyword,
+      ...buildCursorParams(cursor),
+    },
+  });
+
+  return normalizePagedResponse(data, "users");
+};
+
+export const fetchSearchPostsPage = async ({
+  keyword,
+  channel,
+  sort,
+  cursor,
+}) => {
+  const { data } = await api.get(`${SEARCH_BASE_PATH}/posts`, {
+    params: {
+      keyword,
+      channel,
+      sort,
+      ...buildCursorParams(cursor),
+    },
+  });
+
+  return normalizePagedResponse(data, "posts");
+};
+
+export const fetchSearchHashtagsPage = async ({ keyword, cursor }) => {
+  const { data } = await api.get(`${SEARCH_BASE_PATH}/hashtags`, {
+    params: {
+      keyword,
+      ...buildCursorParams(cursor),
+    },
+  });
+
+  return normalizePagedResponse(data, "hashtags");
+};

--- a/src/features/search/services/searchKeys.js
+++ b/src/features/search/services/searchKeys.js
@@ -1,0 +1,15 @@
+export const searchKeys = {
+  all: ["search"],
+  logs: () => [...searchKeys.all, "logs"],
+  suggestions: (keyword) => [...searchKeys.all, "suggestions", { keyword }],
+  users: (keyword) => [...searchKeys.all, "results", "users", { keyword }],
+  posts: (keyword, channel, sort) => [
+    ...searchKeys.all,
+    "results",
+    "posts",
+    { keyword, channel, sort },
+  ],
+  hashtags: (keyword) => [...searchKeys.all, "results", "hashtags", { keyword }],
+};
+
+export default searchKeys;

--- a/src/features/search/services/useDeleteSearchLogMutation.js
+++ b/src/features/search/services/useDeleteSearchLogMutation.js
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteMySearchLog } from "./searchApi";
+import { searchKeys } from "./searchKeys";
+
+export const useDeleteSearchLogMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteMySearchLog,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: searchKeys.logs(),
+      });
+    },
+  });
+};
+
+export default useDeleteSearchLogMutation;

--- a/src/features/search/services/useSearchHashtagsInfiniteQuery.js
+++ b/src/features/search/services/useSearchHashtagsInfiniteQuery.js
@@ -1,0 +1,28 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchSearchHashtagsPage } from "./searchApi";
+import { searchKeys } from "./searchKeys";
+
+export const useSearchHashtagsInfiniteQuery = ({
+  keyword,
+  enabled = true,
+} = {}) => {
+  return useInfiniteQuery({
+    queryKey: searchKeys.hashtags(keyword),
+    queryFn: ({ pageParam }) =>
+      fetchSearchHashtagsPage({
+        keyword,
+        cursor: pageParam ?? null,
+      }),
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage?.hasNext || !lastPage?.nextCursor) {
+        return undefined;
+      }
+
+      return lastPage.nextCursor;
+    },
+    enabled: enabled && Boolean(keyword?.trim()),
+  });
+};
+
+export default useSearchHashtagsInfiniteQuery;

--- a/src/features/search/services/useSearchMyLogsQuery.js
+++ b/src/features/search/services/useSearchMyLogsQuery.js
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchMySearchLogs } from "./searchApi";
+import { searchKeys } from "./searchKeys";
+
+export const useSearchMyLogsQuery = ({ enabled = true } = {}) => {
+  return useQuery({
+    queryKey: searchKeys.logs(),
+    queryFn: fetchMySearchLogs,
+    enabled,
+  });
+};
+
+export default useSearchMyLogsQuery;

--- a/src/features/search/services/useSearchPostsInfiniteQuery.js
+++ b/src/features/search/services/useSearchPostsInfiniteQuery.js
@@ -1,0 +1,36 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchSearchPostsPage } from "./searchApi";
+import { searchKeys } from "./searchKeys";
+
+export const useSearchPostsInfiniteQuery = ({
+  keyword,
+  channel,
+  sort,
+  enabled = true,
+} = {}) => {
+  return useInfiniteQuery({
+    queryKey: searchKeys.posts(keyword, channel, sort),
+    queryFn: ({ pageParam }) =>
+      fetchSearchPostsPage({
+        keyword,
+        channel,
+        sort,
+        cursor: pageParam ?? null,
+      }),
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage?.hasNext || !lastPage?.nextCursor) {
+        return undefined;
+      }
+
+      return lastPage.nextCursor;
+    },
+    enabled:
+      enabled &&
+      Boolean(keyword?.trim()) &&
+      Boolean(channel) &&
+      Boolean(sort),
+  });
+};
+
+export default useSearchPostsInfiniteQuery;

--- a/src/features/search/services/useSearchSuggestionsQuery.js
+++ b/src/features/search/services/useSearchSuggestionsQuery.js
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchSearchSuggestions } from "./searchApi";
+import { searchKeys } from "./searchKeys";
+
+export const useSearchSuggestionsQuery = ({
+  keyword,
+  enabled = true,
+} = {}) => {
+  return useQuery({
+    queryKey: searchKeys.suggestions(keyword),
+    queryFn: () => fetchSearchSuggestions(keyword),
+    enabled: enabled && Boolean(keyword?.trim()),
+  });
+};
+
+export default useSearchSuggestionsQuery;

--- a/src/features/search/services/useSearchUsersInfiniteQuery.js
+++ b/src/features/search/services/useSearchUsersInfiniteQuery.js
@@ -1,0 +1,28 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchSearchUsersPage } from "./searchApi";
+import { searchKeys } from "./searchKeys";
+
+export const useSearchUsersInfiniteQuery = ({
+  keyword,
+  enabled = true,
+} = {}) => {
+  return useInfiniteQuery({
+    queryKey: searchKeys.users(keyword),
+    queryFn: ({ pageParam }) =>
+      fetchSearchUsersPage({
+        keyword,
+        cursor: pageParam ?? null,
+      }),
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage?.hasNext || !lastPage?.nextCursor) {
+        return undefined;
+      }
+
+      return lastPage.nextCursor;
+    },
+    enabled: enabled && Boolean(keyword?.trim()),
+  });
+};
+
+export default useSearchUsersInfiniteQuery;

--- a/src/features/search/utils/formatters.js
+++ b/src/features/search/utils/formatters.js
@@ -1,0 +1,57 @@
+export const getErrorMessage = (error, fallbackMessage) => {
+  return (
+    error?.response?.data?.message ??
+    error?.message ??
+    fallbackMessage
+  );
+};
+
+export const formatRelativeTime = (value) => {
+  if (!value) {
+    return "";
+  }
+
+  const targetDate = new Date(value);
+
+  if (Number.isNaN(targetDate.getTime())) {
+    return "";
+  }
+
+  const diffMs = Date.now() - targetDate.getTime();
+  const diffMinutes = Math.max(1, Math.floor(diffMs / (1000 * 60)));
+
+  if (diffMinutes < 60) {
+    return `${diffMinutes}분`;
+  }
+
+  const diffHours = Math.floor(diffMinutes / 60);
+
+  if (diffHours < 24) {
+    return `${diffHours}시간`;
+  }
+
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffDays < 7) {
+    return `${diffDays}일`;
+  }
+
+  const year = targetDate.getFullYear();
+  const month = `${targetDate.getMonth() + 1}`.padStart(2, "0");
+  const date = `${targetDate.getDate()}`.padStart(2, "0");
+
+  return `${year}.${month}.${date}`;
+};
+
+export const getTotalEmotionCount = (emotions) => {
+  if (!emotions) {
+    return 0;
+  }
+
+  return (
+    (emotions.likeCount ?? 0) +
+    (emotions.sadCount ?? 0) +
+    (emotions.funCount ?? 0) +
+    (emotions.hypeCount ?? 0)
+  );
+};

--- a/src/features/search/utils/queryGuards.js
+++ b/src/features/search/utils/queryGuards.js
@@ -1,0 +1,13 @@
+export const isPureChoseongQuery = (value) => {
+  if (!value) {
+    return false;
+  }
+
+  const compactValue = value.replace(/\s+/g, "");
+
+  if (!compactValue) {
+    return false;
+  }
+
+  return /^[ㄱ-ㅎ]+$/.test(compactValue);
+};


### PR DESCRIPTION
## 요약

- 검색 API 연동 및 검색 화면 구현
- 게시글/계정/태그 검색 결과, 최근 검색어, 추천 검색어 기능 추가
- 홈에서 검색 화면으로 진입할 수 있도록 네비게이션 연결

## 작업 내용

### 검색 화면 및 결과 조회 기능 추가 - 3ef6022
- 최근 검색어, 추천 검색어/추천 계정, 탭별 검색 결과로 이어지는 검색 화면 흐름 구현

- 게시글/계정/태그 검색 API 연동 및 커서 기반 페이징 적용

- 게시글 검색에 정렬/채널 필터 UI 추가

- 게시글 검색 결과 카드를 기존 커뮤니티 화면 톤에 맞게 정리

- 초성 입력 시 추천 요청이 불필요하게 나가지 않도록 처리


### 네비게이션 연결 - a733a06
- 루트 네비게이터에 검색 화면 등록 및 홈 검색 버튼 연결

## 중점 사항
- 검색 결과는 게시글/계정/태그 탭으로 분리하고, 각 탭별 API 응답에 맞춰 목록을 구성했습니다.
- 게시글 검색은 백엔드 정렬 스펙에 맞춰 추천순/인기순/최신순과 전체/내 팀 필터를 함께 적용할 수 있도록 구현했습니다.
- 입력 중 추천과 검색 완료 결과를 분리해, 최근 검색어/추천 검색어/검색 결과 화면 전환 흐름을 정리했습니다.
- 추천 사용자 클릭 시 검색 결과 탭으로 이동하지 않고 바로 프로필 화면으로 이동하도록 맞췄습니다.
- 게시글 검색 결과 카드는 기존 커뮤니티 화면과 최대한 비슷한 톤으로 보이도록 정리하고, 검색 스니펫/하이라이트를 함께 표시하도록 적용했습니다.

## 기타 참고사항
- 게시글 검색결과 추천순 무한스크롤 시 동일 id가 중복으로 내려오는 경우가 있어 
   프론트에서 중복 제거 처리를 했고 관련 백엔드 로직 확인해보겠습니다. 
    