### PR TITLE
Feat/24-push-notification : FCM 연동 및 디바이스 푸시 토큰 동기화 구현

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,24 +1,141 @@
 // app.config.js
+import { withDangerousMod, withEntitlementsPlist } from "@expo/config-plugins";
 import "dotenv/config";
+import fs from "fs";
+import path from "path";
 
-export default ({ config }) => ({
-  ...config,
-  extra: {
-    ...config.extra,
-    backendUrl: process.env.EXPO_PUBLIC_BACKEND_URL,
-    naverClientId: process.env.NAVER_CLIENT_ID,
-    naverClientSecret: process.env.NAVER_CLIENT_SECRET,
-    naverAppName: process.env.NAVER_APP_NAME,
-    naverIosUrlScheme: process.env.NAVER_IOS_URL_SCHEME,
-  },
-  plugins: [
-    ...(config.plugins || []),
-    "expo-secure-store",
-    [
-      "@react-native-seoul/naver-login",
-      {
-        urlScheme: process.env.NAVER_IOS_URL_SCHEME,
-      },
+const IOS_BUNDLE_IDENTIFIER_FALLBACK = "com.beta.baseballapp";
+
+const getResolvedIosBundleIdentifier = (config) =>
+  process.env.IOS_BUNDLE_IDENTIFIER ||
+  config.ios?.bundleIdentifier ||
+  IOS_BUNDLE_IDENTIFIER_FALLBACK;
+
+const resolveIosGoogleServicesFile = (bundleIdentifier) => {
+  if (bundleIdentifier === "com.beta.ohs") {
+    return "./fcm-ios-com-beta-ohs.plist";
+  }
+
+  return "./fcm-ios-com-beta-baseballapp.plist";
+};
+
+const withoutExpoAppleAuthenticationPlugin = (plugins = []) =>
+  plugins.filter((plugin) => {
+    if (Array.isArray(plugin)) {
+      return plugin[0] !== "expo-apple-authentication";
+    }
+
+    return plugin !== "expo-apple-authentication";
+  });
+
+const withLocalOhsEntitlementsFix = (config, { isLocalOhsBuild }) =>
+  withEntitlementsPlist(config, (modConfig) => {
+    if (isLocalOhsBuild) {
+      delete modConfig.modResults["com.apple.developer.applesignin"];
+    }
+
+    return modConfig;
+  });
+
+const withRnFirebaseIosNativeFixes = (config) =>
+  withDangerousMod(config, [
+    "ios",
+    async (modConfig) => {
+      const iosRoot = modConfig.modRequest.platformProjectRoot;
+      const podfilePath = path.join(iosRoot, "Podfile");
+
+      let podfileContents = fs.readFileSync(podfilePath, "utf8");
+
+      if (!podfileContents.includes("$RNFirebaseAsStaticFramework = true")) {
+        podfileContents = podfileContents.replace(
+          "prepare_react_native_project!\n\n",
+          "prepare_react_native_project!\n\n$RNFirebaseAsStaticFramework = true\n\n",
+        );
+      }
+
+      if (
+        !podfileContents.includes(
+          "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES",
+        )
+      ) {
+        podfileContents = podfileContents.replace(
+          `    react_native_post_install(
+      installer,
+      config[:reactNativePath],
+      :mac_catalyst_enabled => false,
+      :ccache_enabled => ccache_enabled?(podfile_properties),
+    )
+  end
+end
+`,
+          `    react_native_post_install(
+      installer,
+      config[:reactNativePath],
+      :mac_catalyst_enabled => false,
+      :ccache_enabled => ccache_enabled?(podfile_properties),
+    )
+
+    installer.pods_project.targets.each do |target|
+      next unless target.name.start_with?('RNFB')
+
+      target.build_configurations.each do |build_configuration|
+        build_configuration.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
+      end
+    end
+  end
+end
+`,
+        );
+      }
+
+      fs.writeFileSync(podfilePath, podfileContents);
+      return modConfig;
+    },
+  ]);
+
+export default ({ config }) => {
+  const resolvedIosBundleIdentifier = getResolvedIosBundleIdentifier(config);
+  const isLocalOhsBuild = resolvedIosBundleIdentifier === "com.beta.ohs";
+  const basePlugins = isLocalOhsBuild
+    ? withoutExpoAppleAuthenticationPlugin(config.plugins || [])
+    : config.plugins || [];
+
+  const baseConfig = withLocalOhsEntitlementsFix({
+    ...config,
+    ios: {
+      ...config.ios,
+      bundleIdentifier: resolvedIosBundleIdentifier,
+      usesAppleSignIn: !isLocalOhsBuild,
+      googleServicesFile: resolveIosGoogleServicesFile(
+        resolvedIosBundleIdentifier,
+      ),
+    },
+    android: {
+      ...config.android,
+      googleServicesFile: "./fcm-android-com-beta-baseballapp.json",
+    },
+    extra: {
+      ...config.extra,
+      backendUrl:
+        process.env.BACKEND_URL || process.env.EXPO_PUBLIC_BACKEND_URL,
+      naverClientId: process.env.NAVER_CLIENT_ID,
+      naverClientSecret: process.env.NAVER_CLIENT_SECRET,
+      naverAppName: process.env.NAVER_APP_NAME,
+      naverIosUrlScheme: process.env.NAVER_IOS_URL_SCHEME,
+    },
+    plugins: [
+      ...basePlugins,
+      "@react-native-firebase/app",
+      "@react-native-firebase/messaging",
+      "expo-secure-store",
+      [
+        "@react-native-seoul/naver-login",
+        {
+          urlScheme: process.env.NAVER_IOS_URL_SCHEME,
+        },
+      ],
     ],
-  ],
-});
+  }, { isLocalOhsBuild });
+
+  return withRnFirebaseIosNativeFixes(baseConfig);
+};

--- a/app.json
+++ b/app.json
@@ -49,7 +49,6 @@
     "plugins": [
       "react-native-vision-camera",
       "expo-font",
-      "expo-build-properties",
       [
         "@react-native-seoul/kakao-login",
         {
@@ -60,6 +59,9 @@
       [
         "expo-build-properties",
         {
+          "ios": {
+            "useFrameworks": "static"
+          },
           "android": {
             "extraMavenRepos": [
               "https://devrepo.kakao.com/nexus/content/groups/public/"

--- a/fcm-android-com-beta-baseballapp.json
+++ b/fcm-android-com-beta-baseballapp.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "272348139360",
+    "project_id": "beta-c3057",
+    "storage_bucket": "beta-c3057.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:272348139360:android:e811db48ec24180032d805",
+        "android_client_info": {
+          "package_name": "com.beta.baseballapp"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAkfpLtEOO1N5U8Z77DEY43VcaG1GEJcgw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/fcm-ios-com-beta-baseballapp.plist
+++ b/fcm-ios-com-beta-baseballapp.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyCOlhptXjiOHl3PLUhrdN8JvMaKrGc5ya4</string>
+	<key>GCM_SENDER_ID</key>
+	<string>272348139360</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.beta.baseballapp</string>
+	<key>PROJECT_ID</key>
+	<string>beta-c3057</string>
+	<key>STORAGE_BUCKET</key>
+	<string>beta-c3057.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:272348139360:ios:033cc3e9b61c829132d805</string>
+</dict>
+</plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,12 @@
     "": {
       "name": "beta",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@expo/metro-config": "~54.0.2",
         "@react-native-community/netinfo": "11.4.1",
+        "@react-native-firebase/app": "^23.8.8",
+        "@react-native-firebase/messaging": "^23.8.8",
         "@react-native-seoul/kakao-login": "^5.4.2",
         "@react-native-seoul/naver-login": "^4.2.3",
         "@react-navigation/bottom-tabs": "^7.4.8",
@@ -115,7 +118,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1707,7 +1709,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2211,6 +2212,645 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.9.0.tgz",
+      "integrity": "sha512-NPvBBuvdGo9x3esnABAucFYmqbBmXvyTMimBq2PCuLZbdANZoHzGlx7vfzbwNDaEtCBq4RGGNMliLIv6bZ+PtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.20",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.20.tgz",
+      "integrity": "sha512-adGTNVUWH5q66tI/OQuKLSN6mamPpfYhj0radlH2xt+3eL6NFPtXoOs+ulvs+UsmK27vNFx5FjRDfWk+TyduHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/installations": "0.6.20",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.26.tgz",
+      "integrity": "sha512-0j2ruLOoVSwwcXAF53AMoniJKnkwiTjGVfic5LDzqiRkR13vb5j6TXMeix787zbLeQtN/m1883Yv1TxI0gItbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.20",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.7.1",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.9.tgz",
+      "integrity": "sha512-3gtUX0e584MYkKBQMgSECMvE1Dwzg+eONefDQ0wxVSe5YMBsZwdN5pL7UapwWBlV8+i8QCztF9TP947tEjZAGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.1.tgz",
+      "integrity": "sha512-gmKfwQ2k8aUQlOyRshc+fOQLq0OwUmibIZvpuY1RDNu2ho0aTMlwxOuEiJeYOs7AxzhSx7gnXPFNsXCFbnvXUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.1.tgz",
+      "integrity": "sha512-yjSvSl5B1u4CirnxhzirN1uiTRCRfx+/qtfbyeyI+8Cx8Cw1RWAIO/OqytPSVwLYbJJ1vEC3EHfxazRaMoWKaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.1",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.9.tgz",
+      "integrity": "sha512-e5LzqjO69/N2z7XcJeuMzIp4wWnW696dQeaHAUpQvGk89gIWHAIvG6W+mA3UotGW6jBoqdppEJ9DnuwbcBByug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.9",
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.12.1.tgz",
+      "integrity": "sha512-nXKj7d5bMBlnq6XpcQQpmnSVwEeHBkoVbY/+Wk0P1ebLSICoH4XPtvKOFlXKfIHmcS84mLQ99fk3njlDGKSDtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.3.tgz",
+      "integrity": "sha512-nHOkupcYuGVxI1AJJ/OBhLPaRokbP14Gq4nkkoVvf1yvuREEWqdnrYB/CdsSnPxHMAnn5wJIKngxBF9jNX7s/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.12.1",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.1",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.1.tgz",
+      "integrity": "sha512-mFzsm7CLHR60o08S23iLUY8m/i6kLpOK87wdEFPLhdlCahaxKmWOwSVGiWoENYSmFJJoDhrR3gKSCxz7ENdIww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.4.0.tgz",
+      "integrity": "sha512-vLXM6WHNIR3VtEeYNUb/5GTsUOyl3Of4iWNZHBe1i9f88sYFnxybJNWVBjvJ7flhCyF8UdxGpzWcUnv6F5vGfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.1.tgz",
+      "integrity": "sha512-LwIXe8+mVHY5LBPulWECOOIEXDiatyECp/BOlu0gOhe+WOcKjWHROaCbLlkFTgHMY7RHr5MOxkLP/tltWAH3dA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.1.tgz",
+      "integrity": "sha512-heAEVZ9Z8c8PnBUcmGh91JHX0cXcVa1yESW/xkLuwaX7idRFyLiN8sl73KXpR8ZArGoPXVQDanBnk6SQiekRCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/database": "1.1.1",
+        "@firebase/database-types": "1.0.17",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.17.tgz",
+      "integrity": "sha512-4eWaM5fW3qEIHjGzfi3cf0Jpqi1xQsAdT6rSDE1RZPrWu8oGjgrq6ybMjobtyHQFgwGCykBm4YM89qDzc+uG/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.14.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.12.0.tgz",
+      "integrity": "sha512-PM47OyiiAAoAMB8kkq4Je14mTciaRoAPDd3ng3Ckqz9i2TX9D9LfxIRcNzP/OxzNV4uBKRq6lXoOggkJBQR3Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "@firebase/webchannel-wrapper": "1.0.5",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.6.tgz",
+      "integrity": "sha512-NgVyR4hHHN2FvSNQOtbgBOuVsEdD/in30d9FKbEvvITiAChrBN2nBstmhfjI4EOTnHaP8zigwvkNYFI9yKGAkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/firestore": "4.12.0",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.2.tgz",
+      "integrity": "sha512-tHduUD+DeokM3NB1QbHCvEMoL16e8Z8JSkmuVA4ROoJKPxHn8ibnecHPO2e3nVCJR1D9OjuKvxz4gksfq92/ZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.1",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.2.tgz",
+      "integrity": "sha512-YNxgnezvZDkqxqXa6cT7/oTeD4WXbxgIP7qZp4LFnathQv5o2omM6EoIhXiT9Ie5AoQDcIhG9Y3/dj+DFJGaGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/functions": "0.13.2",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.20",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.20.tgz",
+      "integrity": "sha512-LOzvR7XHPbhS0YB5ANXhqXB5qZlntPpwU/4KFwhSNpXNsGk/sBQ9g5hepi0y0/MfenJLe2v7t644iGOOElQaHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/util": "1.14.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.20.tgz",
+      "integrity": "sha512-9C9pL/DIEGucmoPj8PlZTnztbX3nhNj5RTYVpUM7wQq/UlHywaYv99969JU/WHLvi9ptzIogXYS9d1eZ6XFe9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/installations": "0.6.20",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.24",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.24.tgz",
+      "integrity": "sha512-UtKoubegAhHyehcB7iQjvQ8OVITThPbbWk3g2/2ze42PrQr6oe6OmCElYQkBrE5RDCeMTNucXejbdulrQ2XwVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/installations": "0.6.20",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.14.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.24.tgz",
+      "integrity": "sha512-wXH8FrKbJvFuFe6v98TBhAtvgknxKIZtGM/wCVsfpOGmaAE80bD8tBxztl+uochjnFb9plihkd6mC4y7sZXSpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/messaging": "0.12.24",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.10.tgz",
+      "integrity": "sha512-8nRFld+Ntzp5cLKzZuG9g+kBaSn8Ks9dmn87UQGNFDygbmR6ebd8WawauEXiJjMj1n70ypkvAOdE+lzeyfXtGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/installations": "0.6.20",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.23.tgz",
+      "integrity": "sha512-c7qOAGBUAOpIuUlHu1axWcrCVtIYKPMhH0lMnoCDWnPwn1HcPuPUBVTWETbC7UWw71RMJF8DpirfWXzMWJQfgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.10",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.1.tgz",
+      "integrity": "sha512-L86TReBnPiiJOWd7k9iaiE9f7rHtMpjAoYN0fH2ey2ZRzsOChHV0s5sYf1+IIUYzplzsE46pjlmAUNkRRKwHSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/installations": "0.6.20",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.22.tgz",
+      "integrity": "sha512-uW/eNKKtRBot2gnCC5mnoy5Voo2wMzZuQ7dwqqGHU176fO9zFgMwKiRzk+aaC99NLrFk1KOmr0ZVheD+zdJmjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.8.1",
+        "@firebase/remote-config-types": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
+      "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.1.tgz",
+      "integrity": "sha512-uIpYgBBsv1vIET+5xV20XT7wwqV+H4GFp6PBzfmLUcEgguS4SWNFof56Z3uOC2lNDh0KDda1UflYq2VwD9Nefw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.1.tgz",
+      "integrity": "sha512-bgl3FHHfXAmBgzIK/Fps6Xyv2HiAQlSTov07CBL+RGGhrC5YIk4lruS8JVIC+UkujRdYvnf8cpQFGn2RCilJ/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/storage": "0.14.1",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.14.0.tgz",
+      "integrity": "sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.5.tgz",
+      "integrity": "sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -2516,6 +3156,70 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@react-native-community/netinfo": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
@@ -2523,6 +3227,40 @@
       "license": "MIT",
       "peerDependencies": {
         "react-native": ">=0.59"
+      }
+    },
+    "node_modules/@react-native-firebase/app": {
+      "version": "23.8.8",
+      "resolved": "https://registry.npmjs.org/@react-native-firebase/app/-/app-23.8.8.tgz",
+      "integrity": "sha512-9KeKToqsEPhaL+KlTYIdUB0bsXYAcKk0Zzpu608zf2qsXbyTscuYs1caLWxk8AdGtt3+j7ZsoOFt/8qnlo4Ugg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "firebase": "12.10.0"
+      },
+      "peerDependencies": {
+        "expo": ">=47.0.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native-firebase/messaging": {
+      "version": "23.8.8",
+      "resolved": "https://registry.npmjs.org/@react-native-firebase/messaging/-/messaging-23.8.8.tgz",
+      "integrity": "sha512-7Po3/0M9SjYftWFZDueNqvbYDgycE/p7rYrcPDBjxWXsVPO98woLPIFRDuYIJDlTVFyYFjpCTF8kDIGBWPTFzQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@react-native-firebase/app": "23.8.8",
+        "expo": ">=47.0.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-seoul/kakao-login": {
@@ -2940,7 +3678,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.33.tgz",
       "integrity": "sha512-DpFdWGcgLajKZ1TuIvDNQsblN2QaUFWpTQaB8v7WRP9Mix8H/6TFoIrZd93pbymI2hybd6UYrD+lI408eWVcfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.16.1",
         "escape-string-regexp": "^4.0.0",
@@ -3174,7 +3911,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4300,7 +5036,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5349,7 +6084,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -5564,7 +6298,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6047,6 +6780,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -6161,6 +6906,42 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.10.0.tgz",
+      "integrity": "sha512-tAjHnEirksqWpa+NKDUSUMjulOnsTcsPC1X1rQ+gwPtjlhJS572na91CwaBXQJHXharIrfj7sw/okDkXOsphjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.9.0",
+        "@firebase/analytics": "0.10.20",
+        "@firebase/analytics-compat": "0.2.26",
+        "@firebase/app": "0.14.9",
+        "@firebase/app-check": "0.11.1",
+        "@firebase/app-check-compat": "0.4.1",
+        "@firebase/app-compat": "0.5.9",
+        "@firebase/app-types": "0.9.3",
+        "@firebase/auth": "1.12.1",
+        "@firebase/auth-compat": "0.6.3",
+        "@firebase/data-connect": "0.4.0",
+        "@firebase/database": "1.1.1",
+        "@firebase/database-compat": "2.1.1",
+        "@firebase/firestore": "4.12.0",
+        "@firebase/firestore-compat": "0.4.6",
+        "@firebase/functions": "0.13.2",
+        "@firebase/functions-compat": "0.4.2",
+        "@firebase/installations": "0.6.20",
+        "@firebase/installations-compat": "0.2.20",
+        "@firebase/messaging": "0.12.24",
+        "@firebase/messaging-compat": "0.2.24",
+        "@firebase/performance": "0.7.10",
+        "@firebase/performance-compat": "0.2.23",
+        "@firebase/remote-config": "0.8.1",
+        "@firebase/remote-config-compat": "0.2.22",
+        "@firebase/storage": "0.14.1",
+        "@firebase/storage-compat": "0.4.1",
+        "@firebase/util": "1.14.0"
       }
     },
     "node_modules/flow-enums-runtime": {
@@ -6552,6 +7333,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -6570,6 +7357,12 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -7007,7 +7800,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7407,6 +8199,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -7501,6 +8299,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -8740,7 +9544,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -9054,6 +9857,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -9153,7 +9980,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9173,7 +9999,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -9204,7 +10029,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.4.tgz",
       "integrity": "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.4",
@@ -9570,7 +10394,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.6.tgz",
       "integrity": "sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -9599,7 +10422,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -9610,7 +10432,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -9635,7 +10456,6 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
       "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -9737,7 +10557,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -10755,7 +11574,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -10984,7 +11802,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11035,7 +11852,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-detect": {
@@ -11279,11 +12095,40 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@expo/metro-config": "~54.0.2",
     "@react-native-community/netinfo": "11.4.1",
+    "@react-native-firebase/app": "^23.8.8",
+    "@react-native-firebase/messaging": "^23.8.8",
     "@react-native-seoul/kakao-login": "^5.4.2",
     "@react-native-seoul/naver-login": "^4.2.3",
     "@react-navigation/bottom-tabs": "^7.4.8",

--- a/src/app/AppProviders.js
+++ b/src/app/AppProviders.js
@@ -14,6 +14,7 @@ import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { initializeNaver } from "../features/auth/libs/Login/naverInit";
 import { hydrateUserEmotionSelectionsFromStorage } from "../features/community/store/userEmotionSelectionStore";
+import PushDeviceBootstrap from "../shared/component/PushDeviceBootstrap";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -91,6 +92,7 @@ const AppProviders = ({ children }) => {
     <SafeAreaProvider>
       <QueryClientProvider client={queryClient}>
         <NavigationContainer>{children}</NavigationContainer>
+        <PushDeviceBootstrap />
       </QueryClientProvider>
     </SafeAreaProvider>
   );

--- a/src/shared/component/PushDeviceBootstrap.jsx
+++ b/src/shared/component/PushDeviceBootstrap.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef } from "react";
+import { AppState } from "react-native";
+
+import { useUserStore } from "../store/userStore";
+import {
+  subscribePushTokenRefresh,
+  syncCurrentDevicePushSettings,
+} from "../services/pushDeviceService";
+
+const PushDeviceBootstrap = () => {
+  const accessToken = useUserStore((state) => state.accessToken);
+  const syncedTokenRef = useRef(null);
+
+  useEffect(() => {
+    if (!accessToken) {
+      syncedTokenRef.current = null;
+      return;
+    }
+
+    if (syncedTokenRef.current === accessToken) {
+      return;
+    }
+
+    syncedTokenRef.current = accessToken;
+
+    syncCurrentDevicePushSettings({ requestPermission: true }).catch((error) => {
+      console.warn("[푸시] 로그인 후 디바이스 푸시 설정 동기화에 실패했습니다.", error);
+    });
+  }, [accessToken]);
+
+  useEffect(() => {
+    if (!accessToken) {
+      return undefined;
+    }
+
+    const unsubscribe = subscribePushTokenRefresh();
+    return unsubscribe;
+  }, [accessToken]);
+
+  useEffect(() => {
+    if (!accessToken) {
+      return undefined;
+    }
+
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state !== "active") {
+        return;
+      }
+
+      syncCurrentDevicePushSettings({ requestPermission: false }).catch(
+        (error) => {
+          console.warn("[푸시] 앱 활성화 후 디바이스 푸시 설정 동기화에 실패했습니다.", error);
+        },
+      );
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [accessToken]);
+
+  return null;
+};
+
+export default PushDeviceBootstrap;

--- a/src/shared/services/pushDeviceService.js
+++ b/src/shared/services/pushDeviceService.js
@@ -1,0 +1,161 @@
+import { PermissionsAndroid, Platform } from "react-native";
+import * as SecureStore from "expo-secure-store";
+import messaging from "@react-native-firebase/messaging";
+
+import api from "../libs/api";
+import { useUserStore } from "../store/userStore";
+import { getDeviceId } from "@features/auth/libs/Login/deviceUtils";
+
+const ANDROID_NOTIFICATION_PERMISSION =
+  PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS;
+
+const isAndroid13OrAbove = () =>
+  Platform.OS === "android" && Number(Platform.Version) >= 33;
+
+const isAuthorizedStatus = (status) =>
+  status === messaging.AuthorizationStatus.AUTHORIZED ||
+  status === messaging.AuthorizationStatus.PROVISIONAL;
+
+const getErrorMessage = (error) =>
+  error?.message ?? error?.nativeErrorMessage ?? String(error ?? "");
+
+async function getAccessToken() {
+  const storeToken = useUserStore.getState().accessToken;
+
+  if (storeToken) {
+    return storeToken;
+  }
+
+  return SecureStore.getItemAsync("accessToken");
+}
+
+async function ensureAndroidNotificationPermission({ requestPermission }) {
+  if (!isAndroid13OrAbove()) {
+    return true;
+  }
+
+  if (!ANDROID_NOTIFICATION_PERMISSION) {
+    return true;
+  }
+
+  if (requestPermission) {
+    const result = await PermissionsAndroid.request(
+      ANDROID_NOTIFICATION_PERMISSION,
+    );
+    return result === PermissionsAndroid.RESULTS.GRANTED;
+  }
+
+  return PermissionsAndroid.check(ANDROID_NOTIFICATION_PERMISSION);
+}
+
+async function ensureIosNotificationPermission({ requestPermission }) {
+  const status = requestPermission
+    ? await messaging().requestPermission()
+    : await messaging().hasPermission();
+
+  return isAuthorizedStatus(status);
+}
+
+async function ensureNotificationPermission({ requestPermission }) {
+  if (Platform.OS === "ios") {
+    return ensureIosNotificationPermission({ requestPermission });
+  }
+
+  if (Platform.OS === "android") {
+    return ensureAndroidNotificationPermission({ requestPermission });
+  }
+
+  return false;
+}
+
+async function getFcmToken() {
+  if (Platform.OS === "ios") {
+    await messaging().registerDeviceForRemoteMessages();
+  }
+
+  return messaging().getToken();
+}
+
+export async function syncCurrentDevicePushSettings({
+  requestPermission = false,
+  overrideFcmToken = null,
+} = {}) {
+  const accessToken = await getAccessToken();
+
+  if (!accessToken) {
+    return { skipped: true, reason: "NO_ACCESS_TOKEN" };
+  }
+
+  const deviceId = await getDeviceId();
+  const hasPermission = await ensureNotificationPermission({ requestPermission });
+
+  let fcmToken = null;
+  let pushEnabled = false;
+  let skippedReason = null;
+
+  if (hasPermission) {
+    try {
+      fcmToken = overrideFcmToken ?? (await getFcmToken());
+      pushEnabled = Boolean(fcmToken);
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+
+      if (
+        Platform.OS === "ios" &&
+        errorMessage.includes("aps-environment")
+      ) {
+        skippedReason = "MISSING_APNS_ENTITLEMENT";
+        console.warn(
+          "[푸시] iOS 푸시 entitlement가 없어 FCM 토큰을 발급할 수 없습니다.",
+        );
+      } else {
+        skippedReason = "FCM_TOKEN_ERROR";
+        console.warn("[푸시] FCM 토큰 발급에 실패했습니다.", error);
+      }
+    }
+  } else {
+    skippedReason = "NOTIFICATION_PERMISSION_NOT_GRANTED";
+  }
+
+  if (!fcmToken) {
+    return {
+      skipped: true,
+      reason: skippedReason ?? "FCM_TOKEN_UNAVAILABLE",
+      deviceId,
+      pushEnabled: false,
+    };
+  }
+
+  await api.put(
+    "/api/v1/devices/push-settings",
+    {
+      deviceId,
+      fcmToken,
+      pushEnabled,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  return {
+    deviceId,
+    fcmToken,
+    pushEnabled,
+  };
+}
+
+export function subscribePushTokenRefresh() {
+  return messaging().onTokenRefresh(async (token) => {
+    try {
+      await syncCurrentDevicePushSettings({
+        requestPermission: false,
+        overrideFcmToken: token,
+      });
+    } catch (error) {
+      console.warn("[푸시] 갱신된 FCM 토큰 동기화에 실패했습니다.", error);
+    }
+  });
+}


### PR DESCRIPTION
## 요약
- FCM 기반 푸시 알림 연동을 위한 프론트 초기 설정과 디바이스 푸시 토큰 동기화 로직을 추가했습니다.
- 로그인 이후 현재 디바이스의 FCM 토큰을 확인하고, 백엔드 /push-settings API로 
   deviceId / fcmToken / pushEnabled를 동기화 하는 흐름을 구현했습니다.

## 작업 내용

#### FCM/네이티브 설정 추가
- @react-native-firebase/app, @react-native-firebase/messaging 의존성 추가
- Expo app config에 Firebase 설정 파일 경로 연결
- Android google-services.json, iOS GoogleService-Info.plist 연동
- 디바이스 푸시 토큰 동기화 로직 추가
- 로컬 iOS 개발용 bundle id(com.beta.ohs) 예외 분기 추가 - **추후 삭제 예정**

#### syncCurrentDevicePushSettings() 서비스 추가
- 현재 로그인 토큰 확인 후 알림 권한 확인/요청
- 권한 허용 시 FCM 토큰 발급 시도
- 발급된 토큰을 백엔드 PUT /api/v1/devices/push-settings로 전송
- 토큰 발급 실패 시 앱이 깨지지 않도록 warn 로그 처리

#### 앱 전역 푸시 bootstrap 연결
 - PushDeviceBootstrap 컴포넌트 추가
   - 로그인 직후 디바이스 푸시 설정 동기화
   - 앱이 background -> active 로 복귀할 때 재동기화
   - Firebase SDK가 FCM 토큰 갱신 이벤트(onTokenRefresh)을 감지하면 재동기화
 - AppProviders에 bootstrap 연결

## 중점 사항
- 백엔드에서 이미 생성 중인 user_devices row에 대해, 프론트가 fcmToken / pushEnabled를 채워 넣는 흐름을 구현했습니다.
- 푸시 발송 자체는 백엔드 책임이므로, 프론트는 `발송에 필요한 디바이스 토큰 최신화`에 초점을 맞췄습니다.
- 푸시 관련 예외 상황에서 앱 전체가 중단되지 않도록 실패를 우선 warn 로그로 처리했습니다.
- OS/Android 권한 처리 방식을 분리해 플랫폼별로 맞는 권한 체크 로직을 적용했습니다.

##  기타 참고사항
- Firebase 콘솔 설정은 완료했는데, iOS에서 실제 FCM 토큰 발급/푸시 수신 검증을 위해서
   Apple Developer의 실제 사용하는 bundle id를 통한 테스트가 필요합니다.
- 회원가입 시 푸시 동의 UI, 설정 화면의 푸시 ON/OFF 토글은 아직 협의하지 않아 범위에서 제외했습니다.
- Firebase 설정 파일(google-services.json, GoogleService-Info.plist)의 관리 방식은 추후 팀 기준에 맞춰 정리하겠습니다.

## 추가 수정 사항
- 푸시 알림 관련 에러 수정 및 일부 UI 보완 사항이 추가 반영되었습니다. [bc9d73e](https://github.com/BETA-BasEball-Together-Always/BETA-Client/commit/bc9d73ece503a7396746b383f4131017af2f1131)

  - 전체 푸시 ON/OFF와 댓글/공감 개별 토글의 연동 로직을 수정했습니다.

  - 실제 푸시 설정값과 화면에 보이는 토글 상태가 다르게 보이던 문제를 함께 수정했습니다.