### PR TITLE
Feat/24-push-notification : 회원가입 후 푸시 권한 요청 및 디바이스 푸시 설정 플로우 구현

### DIFF
--- a/src/features/auth/screens/Login/LoginScreen.jsx
+++ b/src/features/auth/screens/Login/LoginScreen.jsx
@@ -16,7 +16,7 @@ import { kakaoSignIn } from "../../libs/Login/kakaoSignIn";
 import { naverSignIn } from "../../libs/Login/naverSignIn";
 import { appleSignIn } from "../../libs/Login/appleSignIn";
 import { useSocialLoginMutation } from "../../services/socialLoginMutation";
-import { useSignupStatusMutation } from "../../services/signupStatusMutation";
+import { fetchSignupStatusWithToken } from "../../services/signupStatusMutation";
 
 import * as SecureStore from "expo-secure-store";
 import { getDeviceId } from "../../libs/Login/deviceUtils";
@@ -34,7 +34,6 @@ const LoginScreen = ({ navigation, route }) => {
   const [isSocialLoading, setIsSocialLoading] = useState(false);
   const socialLoginMutation = useSocialLoginMutation();
   const [providerConflict, setProviderConflict] = useState(null);
-  const signupStatusMutation = useSignupStatusMutation();
   const setTokens = useUserStore((state) => state.setTokens);
   const setUser = useUserStore((state) => state.setUser);
 
@@ -79,12 +78,13 @@ const LoginScreen = ({ navigation, route }) => {
 
   const handleSocialLoginResult = async (provider, response) => {
     const data = response?.data;
+    const userResponse = data?.userResponse;
     const isNewUser =
       typeof data?.isNewUser === "boolean"
         ? data.isNewUser
-        : // 백엔드 필드명이 newUser로 올 수도 있어 둘 다 지원
-          data?.newUser;
-    const userResponse = data?.userResponse;
+        : typeof data?.newUser === "boolean"
+          ? data.newUser
+          : !userResponse?.user;
 
     if (!userResponse?.accessToken) {
       Alert.alert("로그인 오류", "응답을 처리할 수 없습니다.");
@@ -107,20 +107,33 @@ const LoginScreen = ({ navigation, route }) => {
       return;
     }
 
-    // 신규 or 회원가입 미완료 → 서버에서 최신 signupStep / 데이터 조회
+    // 회원가입 미완료
+    // - SOCIAL_AUTHENTICATED 또는 단계 미표시: 약관만 필요 -> GET /signup/status 생략 가능
+    // - 그 외(CONSENT_AGREED, PROFILE_COMPLETED, TEAM_SELECTED 등): 해당 화면 구성용
+    //   email·teamList 등은 반드시 GET /api/v1/auth/signup/status 로 조회
     let signupStep = userResponse.signupStep;
     let emailFromServer = null;
     let teamListFromServer = null;
 
-    try {
-      const status = await signupStatusMutation.mutateAsync();
-      if (status?.signupStep) {
-        signupStep = status.signupStep;
+    const canSkipSignupStatus =
+      signupStep == null || signupStep === "SOCIAL_AUTHENTICATED";
+
+    if (!canSkipSignupStatus) {
+      try {
+        const status = await fetchSignupStatusWithToken(userResponse.accessToken);
+        if (status?.signupStep) {
+          signupStep = status.signupStep;
+        }
+        emailFromServer = status?.email ?? null;
+        teamListFromServer = status?.teamList ?? null;
+      } catch (e) {
+        console.log("signup/status 조회 실패:", e);
+        Alert.alert(
+          "안내",
+          "회원가입 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
+        );
+        return;
       }
-      emailFromServer = status?.email ?? null;
-      teamListFromServer = status?.teamList ?? null;
-    } catch (e) {
-      console.log("signup/status 조회 실패:", e);
     }
 
     console.log("회원가입 진행 단계 (복원 포함): ", signupStep);
@@ -164,14 +177,11 @@ const LoginScreen = ({ navigation, route }) => {
     if (isSocialLoading) return;
     setIsSocialLoading(true);
 
-    alert("Apple 로그인 시작!!!");
-    const api = require("../../../../shared/libs/api").default;
-    alert("BASE_URL: " + api.defaults.baseURL);
-
     try {
       const { token, cancelled } = await appleSignIn();
       if (cancelled) {
         console.log("Apple 로그인 취소됨");
+        setIsSocialLoading(false);
         return;
       }
 
@@ -179,6 +189,7 @@ const LoginScreen = ({ navigation, route }) => {
 
       if (!token?.identityToken) {
         console.log("identityToken 없음");
+        setIsSocialLoading(false);
         return;
       }
 
@@ -189,24 +200,19 @@ const LoginScreen = ({ navigation, route }) => {
         { provider: "APPLE", token: token.identityToken, deviceId },
         {
           onSuccess: async (response) => {
-            console.log("Apple 로그인 서버 응답 성공!");
-            console.log("전체 응답: ", response?.data);
+            const userResponse = response.data?.userResponse;
 
-            const { isNewUser, userResponse } = response.data;
+            try {
+              // 토큰은 전역 store + SecureStore에 동시 저장
+              await setTokens({
+                accessToken: userResponse.accessToken,
+                refreshToken: userResponse.refreshToken,
+              });
 
-            console.log("isNewUser: ", isNewUser);
-            console.log("accessToken: ", userResponse?.accessToken);
-            console.log("refreshToken: ", userResponse?.refreshToken);
-            console.log("서버 device id: ", userResponse?.deviceId);
-
-            // 토큰은 전역 store + SecureStore에 동시 저장
-            await setTokens({
-              accessToken: userResponse.accessToken,
-              refreshToken: userResponse.refreshToken,
-            });
-
-            console.log("토큰 저장 완료 (store + SecureStore)!");
-            handleSocialLoginResult("APPLE", response);
+              await handleSocialLoginResult("APPLE", response);
+            } finally {
+              setIsSocialLoading(false);
+            }
           },
           onError: (error) => {
             console.log("Apple 서버 로그인 실패");
@@ -221,9 +227,8 @@ const LoginScreen = ({ navigation, route }) => {
               const inferred = inferProviderFromMessage(
                 error?.response?.data?.message,
               );
-              setProviderConflict(
-                socialProvider || inferred || provider || "APPLE",
-              );
+              setProviderConflict(socialProvider || inferred || "APPLE");
+              setIsSocialLoading(false);
               return;
             }
 
@@ -232,6 +237,7 @@ const LoginScreen = ({ navigation, route }) => {
               "애플 로그인 실패",
               "잠시 후 다시 시도해 주세요.",
             );
+            setIsSocialLoading(false);
           },
         },
       );
@@ -245,7 +251,6 @@ const LoginScreen = ({ navigation, route }) => {
         "애플 로그인 실패",
         "잠시 후 다시 시도해 주세요.",
       );
-    } finally {
       setIsSocialLoading(false);
     }
   };
@@ -256,7 +261,10 @@ const LoginScreen = ({ navigation, route }) => {
 
     try {
       const { token, profile, cancelled } = await kakaoSignIn();
-      if (cancelled) return;
+      if (cancelled) {
+        setIsSocialLoading(false);
+        return;
+      }
 
       console.log("카카오 토큰:", token);
       console.log("카카오 프로필:", profile);
@@ -270,12 +278,16 @@ const LoginScreen = ({ navigation, route }) => {
           onSuccess: async (response) => {
             const userResponse = response.data.userResponse;
 
-            await setTokens({
-              accessToken: userResponse.accessToken,
-              refreshToken: userResponse.refreshToken,
-            });
+            try {
+              await setTokens({
+                accessToken: userResponse.accessToken,
+                refreshToken: userResponse.refreshToken,
+              });
 
-            handleSocialLoginResult("KAKAO", response);
+              await handleSocialLoginResult("KAKAO", response);
+            } finally {
+              setIsSocialLoading(false);
+            }
           },
           onError: (error) => {
             console.log("카카오 서버 로그인 실패");
@@ -290,9 +302,8 @@ const LoginScreen = ({ navigation, route }) => {
               const inferred = inferProviderFromMessage(
                 error?.response?.data?.message,
               );
-              setProviderConflict(
-                socialProvider || inferred || provider || "KAKAO",
-              );
+              setProviderConflict(socialProvider || inferred || "KAKAO");
+              setIsSocialLoading(false);
               return;
             }
             if (error?.response?.status === 400 && code === "SOCIAL004") {
@@ -300,6 +311,7 @@ const LoginScreen = ({ navigation, route }) => {
                 error?.response?.data?.message ??
                 "카카오 계정에 이메일이 등록되어 있지 않습니다.";
               Alert.alert("카카오 로그인 오류", msg);
+              setIsSocialLoading(false);
               return;
             }
             showApiAuthError(
@@ -307,6 +319,7 @@ const LoginScreen = ({ navigation, route }) => {
               "카카오 로그인 실패",
               "잠시 후 다시 시도해주세요.",
             );
+            setIsSocialLoading(false);
           },
         },
       );
@@ -317,7 +330,6 @@ const LoginScreen = ({ navigation, route }) => {
         "카카오 로그인 실패",
         "잠시 후 다시 시도해주세요.",
       );
-    } finally {
       setIsSocialLoading(false);
     }
   };
@@ -328,9 +340,29 @@ const LoginScreen = ({ navigation, route }) => {
 
     try {
       console.log("[NAVER] 로그인 버튼 클릭");
-      const { token, profile, cancelled } = await naverSignIn();
+      const naverResult = await naverSignIn();
+      const { token, profile, cancelled } = naverResult;
       if (cancelled) {
-        console.log("[NAVER] 로그인 취소/중단됨");
+        if (naverResult.missingConfig) {
+          Alert.alert(
+            "네이버 로그인",
+            "네이버 앱 연동 설정이 비어 있습니다. NAVER_CLIENT_ID, NAVER_CLIENT_SECRET, NAVER_APP_NAME, NAVER_IOS_URL_SCHEME(.env)을 채운 뒤 prebuild/재빌드해 주세요.",
+          );
+        } else if (naverResult.timeout) {
+          Alert.alert(
+            "네이버 로그인",
+            "응답 시간이 초과되었습니다. 네이버 앱 설치 여부와 URL Scheme 설정을 확인한 뒤 다시 시도해 주세요.",
+          );
+        } else if (naverResult.errorMessage) {
+          Alert.alert("네이버 로그인", naverResult.errorMessage);
+        } else if (!naverResult.userCancel) {
+          Alert.alert(
+            "네이버 로그인",
+            "로그인을 완료할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+          );
+        }
+        console.log("[NAVER] 로그인 취소/중단됨", naverResult);
+        setIsSocialLoading(false);
         return;
       }
 
@@ -345,12 +377,16 @@ const LoginScreen = ({ navigation, route }) => {
           onSuccess: async (response) => {
             const userResponse = response.data.userResponse;
 
-            await setTokens({
-              accessToken: userResponse.accessToken,
-              refreshToken: userResponse.refreshToken,
-            });
+            try {
+              await setTokens({
+                accessToken: userResponse.accessToken,
+                refreshToken: userResponse.refreshToken,
+              });
 
-            handleSocialLoginResult("NAVER", response);
+              await handleSocialLoginResult("NAVER", response);
+            } finally {
+              setIsSocialLoading(false);
+            }
           },
           onError: (error) => {
             console.log("네이버 소셜 로그인 실패:", error);
@@ -360,9 +396,8 @@ const LoginScreen = ({ navigation, route }) => {
               const inferred = inferProviderFromMessage(
                 error?.response?.data?.message,
               );
-              setProviderConflict(
-                socialProvider || inferred || provider || "NAVER",
-              );
+              setProviderConflict(socialProvider || inferred || "NAVER");
+              setIsSocialLoading(false);
               return;
             }
             if (error?.response?.status === 400 && code === "SOCIAL004") {
@@ -370,6 +405,7 @@ const LoginScreen = ({ navigation, route }) => {
                 error?.response?.data?.message ??
                 "네이버 계정에 이메일이 등록되어 있지 않습니다.";
               Alert.alert("네이버 로그인 오류", msg);
+              setIsSocialLoading(false);
               return;
             }
             showApiAuthError(
@@ -377,6 +413,7 @@ const LoginScreen = ({ navigation, route }) => {
               "네이버 로그인 실패",
               "잠시 후 다시 시도해주세요.",
             );
+            setIsSocialLoading(false);
           },
         },
       );
@@ -388,8 +425,6 @@ const LoginScreen = ({ navigation, route }) => {
         "네이버 로그인 실패",
         "잠시 후 다시 시도해주세요.",
       );
-    } finally {
-      console.log("[NAVER] 로그인 로딩 해제");
       setIsSocialLoading(false);
     }
   };

--- a/src/features/auth/screens/SignupComplete/SignupCompleteScreen.jsx
+++ b/src/features/auth/screens/SignupComplete/SignupCompleteScreen.jsx
@@ -1,25 +1,70 @@
 import React, { useEffect, useState } from "react";
-import { StyleSheet, View, SafeAreaView, TouchableOpacity } from "react-native";
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import * as SecureStore from "expo-secure-store";
+import { SafeAreaView } from "react-native-safe-area-context";
+
 import { AppText } from "../../../../shared/theme/components/AppText";
 import AuthBackground from "../../components/AuthBackground";
 import CompleteIcon from "../../assets/common/svg/signupComplete.svg";
-
-import * as SecureStore from "expo-secure-store";
+import { runSignupPushPermissionFlow } from "../../../../shared/services/pushDeviceService";
 
 const SignupCompleteScreen = ({ navigation, route }) => {
   const [favoriteTeamLabel, setFavoriteTeamLabel] = useState("팬");
+  const [permissionModalVisible, setPermissionModalVisible] = useState(false);
+  const [permissionBusy, setPermissionBusy] = useState(false);
 
   useEffect(() => {
     const labelFromParams = route?.params?.signup?.favoriteTeamLabel;
     if (labelFromParams) {
       setFavoriteTeamLabel(labelFromParams);
     } else {
-      // route.params 없으면 로컬에서 불러오기
       SecureStore.getItemAsync("favoriteTeamLabel").then((stored) => {
-        if (stored) setFavoriteTeamLabel(stored);
+        if (stored) {
+          setFavoriteTeamLabel(stored);
+        }
       });
     }
   }, [route?.params]);
+
+  useEffect(() => {
+    setPermissionModalVisible(true);
+  }, []);
+
+  const moveToMain = () => {
+    navigation.replace("Main");
+  };
+
+  const handleLater = () => {
+    setPermissionModalVisible(false);
+    moveToMain();
+  };
+
+  const handleAllowNotifications = async () => {
+    if (permissionBusy) {
+      return;
+    }
+
+    setPermissionBusy(true);
+    try {
+      const result = await runSignupPushPermissionFlow();
+      if (result?.skipped) {
+        console.warn("[푸시] 회원가입 직후 푸시 권한 처리 건너뜀:", result.reason);
+      }
+    } catch (error) {
+      console.warn("[푸시] 회원가입 직후 푸시 권한 처리 실패:", error);
+    } finally {
+      setPermissionBusy(false);
+      setPermissionModalVisible(false);
+      moveToMain();
+    }
+  };
 
   return (
     <View style={styles.root}>
@@ -37,7 +82,7 @@ const SignupCompleteScreen = ({ navigation, route }) => {
           <View style={styles.buttonContainer}>
             <TouchableOpacity
               style={styles.button}
-              onPress={() => navigation.replace("Main")}
+              onPress={() => setPermissionModalVisible(true)}
             >
               <AppText variant="heading" style={styles.btnText}>
                 응원하러 가기
@@ -46,6 +91,50 @@ const SignupCompleteScreen = ({ navigation, route }) => {
           </View>
         </View>
       </SafeAreaView>
+
+      <Modal
+        transparent
+        visible={permissionModalVisible}
+        animationType="fade"
+        onRequestClose={() => {}}
+      >
+        <View style={styles.sheetOverlay}>
+          <Pressable style={styles.sheetBackdrop} />
+          <View style={styles.sheetCard}>
+            <View style={styles.sheetHandle} />
+            <AppText variant="displayTitle" style={styles.sheetTitle}>
+              알림을 받아보시겠어요?
+            </AppText>
+            <AppText variant="middle" style={styles.sheetDescription}>
+              댓글, 감정 리액션, 공지 알림을 빠르게 받아볼 수 있어요.
+            </AppText>
+
+            <TouchableOpacity
+              style={[styles.primaryButton, permissionBusy && styles.buttonDisabled]}
+              disabled={permissionBusy}
+              onPress={handleAllowNotifications}
+            >
+              {permissionBusy ? (
+                <ActivityIndicator color="#111111" />
+              ) : (
+                <AppText variant="heading" style={styles.primaryButtonText}>
+                  알림 받기
+                </AppText>
+              )}
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[styles.secondaryButton, permissionBusy && styles.buttonDisabled]}
+              disabled={permissionBusy}
+              onPress={handleLater}
+            >
+              <AppText variant="semi16" style={styles.secondaryButtonText}>
+                나중에 설정할게요
+              </AppText>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 };
@@ -90,5 +179,66 @@ const styles = StyleSheet.create({
   },
   btnText: {
     color: "#111111",
+  },
+  sheetOverlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  sheetBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.55)",
+  },
+  sheetCard: {
+    backgroundColor: "#202325",
+    borderTopLeftRadius: 28,
+    borderTopRightRadius: 28,
+    paddingTop: 14,
+    paddingHorizontal: 24,
+    paddingBottom: 38,
+  },
+  sheetHandle: {
+    width: 44,
+    height: 5,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    alignSelf: "center",
+    marginBottom: 18,
+  },
+  sheetTitle: {
+    color: "#FFFFFF",
+    textAlign: "center",
+    marginBottom: 10,
+  },
+  sheetDescription: {
+    color: "rgba(228,228,228,0.70)",
+    textAlign: "center",
+    marginBottom: 26,
+    lineHeight: 22,
+  },
+  primaryButton: {
+    width: "100%",
+    height: 52,
+    borderRadius: 10,
+    backgroundColor: "#FFFFFF",
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  primaryButtonText: {
+    color: "#111111",
+  },
+  secondaryButton: {
+    width: "100%",
+    height: 52,
+    borderRadius: 10,
+    backgroundColor: "rgba(255,255,255,0.08)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  secondaryButtonText: {
+    color: "#F9F9F9",
+  },
+  buttonDisabled: {
+    opacity: 0.7,
   },
 });

--- a/src/features/auth/screens/SignupGenderAge/SignupGenderAgeScreen.jsx
+++ b/src/features/auth/screens/SignupGenderAge/SignupGenderAgeScreen.jsx
@@ -22,6 +22,7 @@ import { useStepBack } from "../../hooks/useStepBack";
 import BackIcon from "../../../../shared/assets/svg/chevrons/back.svg";
 import { AppText } from "../../../../shared/theme/components/AppText";
 import { useUserStore } from "../../../../shared/store/userStore";
+import api from "../../../../shared/libs/api";
 
 const { height } = Dimensions.get("window");
 
@@ -42,6 +43,7 @@ const SignupGenderAgeScreen = ({ navigation, route }) => {
 
   const signupCompleteMutation = useSignupCompleteMutation();
   const setUser = useUserStore((state) => state.setUser);
+  const setTokens = useUserStore((state) => state.setTokens);
 
   // 재진입 시 route.params.signup만 사용해 데이터 복구
   useEffect(() => {
@@ -58,14 +60,22 @@ const SignupGenderAgeScreen = ({ navigation, route }) => {
         age: typeof ageValue === "number" ? ageValue : undefined,
       },
       {
-        onSuccess: (data) => {
+        onSuccess: async (data) => {
+          if (data?.accessToken) {
+            await setTokens({
+              accessToken: data.accessToken,
+              refreshToken: data.refreshToken,
+            });
+            api.defaults.headers.Authorization = `Bearer ${data.accessToken}`;
+          }
+
           // 백엔드에서 최종 UserDto를 내려준다고 가정하고 전역 상태에 저장
           const userDto = data?.user ?? data;
           if (userDto) {
-            setUser(userDto);
+            await setUser(userDto);
           }
 
-            navigation.navigate("SignupComplete", {
+          navigation.navigate("SignupComplete", {
             signup: {
               ...(signupData || {}),
               favoriteTeamLabel:

--- a/src/features/community/component/communityMain/PostList.jsx
+++ b/src/features/community/component/communityMain/PostList.jsx
@@ -14,6 +14,7 @@ const PostList = ({
   isLoading,
   isFeedBusy = false,
   showTeam = false,
+  createPostBoardId,
   removeClippedSubviews,
   stabilizePostBodyMeasure = false,
   sort,
@@ -79,7 +80,13 @@ const PostList = ({
       <TouchableOpacity
         style={styles.fabButton}
         onPress={() =>
-          navigation.navigate("Community", { screen: "CreatePost" })
+          navigation.navigate("Community", {
+            screen: "CreatePost",
+            params:
+              createPostBoardId != null
+                ? { initialBoardId: createPostBoardId }
+                : undefined,
+          })
         }
       >
         <PlusIcon width={16} height={16} />

--- a/src/features/community/screens/AllCommunityScreen.jsx
+++ b/src/features/community/screens/AllCommunityScreen.jsx
@@ -63,6 +63,7 @@ const AllCommunityScreen = ({ route }) => {
             onEndReached={loadMore}
             isLoading={isFetchingNextPage}
             isFeedBusy={isLoading || isFetching}
+            createPostBoardId="ALL"
             showTeam={true}
             sort={sort}
             onSortChange={setSort}

--- a/src/features/community/screens/CreatePost/CreatePostScreen.jsx
+++ b/src/features/community/screens/CreatePost/CreatePostScreen.jsx
@@ -132,6 +132,8 @@ const CreatePostScreen = () => {
   const editPost = route.params?.editPost;
   const isEditMode = !!editPost?.postId;
   const photoBoothAttachNonce = route.params?.photoBoothAttachNonce;
+  const initialBoardId =
+    route.params?.initialBoardId === "ALL" ? "ALL" : "TEAM";
 
   const author = useUserStore((state) => state.user);
   const queryClient = useQueryClient();
@@ -141,7 +143,7 @@ const CreatePostScreen = () => {
   const [content, setContent] = useState(() =>
     isEditMode ? (editPost?.content ?? "") : "",
   );
-  const [selectedBoardId, setSelectedBoardId] = useState("TEAM");
+  const [selectedBoardId, setSelectedBoardId] = useState(initialBoardId);
   /** 수정 모드: 서버에 남길 기존 이미지 */
   const [keptExistingImages, setKeptExistingImages] = useState([]);
   /** 수정 모드: 새로 첨부한 로컬 이미지 */
@@ -194,6 +196,11 @@ const CreatePostScreen = () => {
       setSelectedBoardId("TEAM");
     }
   }, [editPost?.postId, editPost?.channel]);
+
+  useEffect(() => {
+    if (isEditMode) return;
+    setSelectedBoardId(initialBoardId);
+  }, [initialBoardId, isEditMode]);
 
   const totalImageCount = isEditMode
     ? keptExistingImages.length + pendingNewImages.length

--- a/src/features/profile/screens/Setting/ProfileSettingScreen.jsx
+++ b/src/features/profile/screens/Setting/ProfileSettingScreen.jsx
@@ -2,15 +2,22 @@ import React, { useCallback, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  Linking,
   Modal,
+  Platform,
   Pressable,
   StyleSheet,
   TouchableOpacity,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { CommonActions, useNavigation } from "@react-navigation/native";
+import {
+  CommonActions,
+  useFocusEffect,
+  useNavigation,
+} from "@react-navigation/native";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import Constants from "expo-constants";
 
 import AppHeader from "../../../../shared/component/AppHeader";
 import { AppText } from "../../../../shared/theme/components/AppText";
@@ -27,6 +34,85 @@ import {
   getApiErrorUserMessage,
   logAxiosError,
 } from "../../../../shared/utils/debugAxiosError";
+import {
+  fetchCurrentDevicePushSettings,
+  submitPushDetailSettingsToServer,
+  submitPushEnabledToServer,
+} from "../../../../shared/services/pushDeviceService";
+import MoreArrow from "@features/auth/assets/common/svg/more_arrow.svg";
+
+const NOTION_URLS = {
+  notice: "",
+  faq: "",
+  termsOfService:
+    "https://www.notion.so/29b226b7125d800c92c9e2d4fca7696e?source=copy_link",
+  privacyPolicy:
+    "https://www.notion.so/2e1226b7125d80398dece59a2b1f0a6b?source=copy_link",
+};
+
+const APP_VERSION = Constants.expoConfig?.version ?? "1.0.0";
+const PUSH_TOGGLE_W = 54;
+const PUSH_TOGGLE_H = 33;
+const PUSH_TOGGLE_THUMB = 28;
+const PUSH_TOGGLE_PAD = 2.5;
+const EMPTY_PUSH_SETTINGS = {
+  pushEnabled: false,
+  postCommentPushEnabled: false,
+  postEmotionPushEnabled: false,
+};
+
+function PushSettingToggle({ value, onValueChange, busy }) {
+  return (
+    <Pressable
+      accessibilityRole="switch"
+      accessibilityState={{ checked: value, disabled: busy }}
+      disabled={busy}
+      onPress={() => onValueChange(!value)}
+      style={[
+        styles.pushToggleTrack,
+        value ? styles.pushToggleTrackOn : styles.pushToggleTrackOff,
+      ]}
+    >
+      <View
+        style={[
+          styles.pushToggleInner,
+          { justifyContent: value ? "flex-end" : "flex-start" },
+        ]}
+      >
+        <View style={styles.pushToggleThumb} />
+      </View>
+    </Pressable>
+  );
+}
+
+function PushSettingRow({
+  title,
+  description,
+  value,
+  onValueChange,
+  busy,
+  showDivider = true,
+}) {
+  return (
+    <View style={[styles.pushItem, showDivider && styles.pushItemDivider]}>
+      <View style={styles.pushItemTextWrap}>
+        <AppText variant="semi16" style={styles.pushItemTitle}>
+          {title}
+        </AppText>
+        {description ? (
+          <AppText variant="smallRegular" style={styles.pushItemDescription}>
+            {description}
+          </AppText>
+        ) : null}
+      </View>
+      <PushSettingToggle
+        value={value}
+        onValueChange={onValueChange}
+        busy={busy}
+      />
+    </View>
+  );
+}
 
 const LOGOUT_SUB =
   "계정에서 로그아웃됩니다.\n언제든 다시 로그인하실 수 있어요.";
@@ -36,10 +122,32 @@ const WITHDRAW_SUB =
 const ProfileSettingScreen = () => {
   const navigation = useNavigation();
   const queryClient = useQueryClient();
-  const clearAuth = useUserStore((s) => s.clearAuth);
+  const clearAuth = useUserStore((state) => state.clearAuth);
 
   const [logoutModalVisible, setLogoutModalVisible] = useState(false);
   const [withdrawModalVisible, setWithdrawModalVisible] = useState(false);
+  const [pushSettings, setPushSettings] = useState(EMPTY_PUSH_SETTINGS);
+  const [pushSettingsLoading, setPushSettingsLoading] = useState(true);
+  const [pushToggleBusy, setPushToggleBusy] = useState(false);
+
+  const refreshPushSettings = useCallback(async () => {
+    try {
+      setPushSettingsLoading(true);
+      const result = await fetchCurrentDevicePushSettings();
+      setPushSettings(result.settings ?? EMPTY_PUSH_SETTINGS);
+    } catch (error) {
+      logAxiosError("fetchDevicePushSettings", error);
+      setPushSettings(EMPTY_PUSH_SETTINGS);
+    } finally {
+      setPushSettingsLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      refreshPushSettings();
+    }, [refreshPushSettings]),
+  );
 
   const resetAppSession = useCallback(async () => {
     await clearAuth();
@@ -73,13 +181,13 @@ const ProfileSettingScreen = () => {
       setLogoutModalVisible(false);
       await resetAppSession();
     },
-    onError: (e) => {
-      logAxiosError("logout", e);
-      const msg = getApiErrorUserMessage(
-        e,
+    onError: (error) => {
+      logAxiosError("logout", error);
+      const message = getApiErrorUserMessage(
+        error,
         "로그아웃에 실패했습니다. 다시 시도해 주세요.",
       );
-      Alert.alert("오류", String(msg));
+      Alert.alert("오류", String(message));
     },
   });
 
@@ -101,17 +209,158 @@ const ProfileSettingScreen = () => {
         await resetAppSession();
       }
     },
-    onError: (e) => {
-      logAxiosError("withdrawAccount", e);
-      const msg = getApiErrorUserMessage(
-        e,
+    onError: (error) => {
+      logAxiosError("withdrawAccount", error);
+      const message = getApiErrorUserMessage(
+        error,
         "회원 탈퇴 요청에 실패했습니다. 다시 시도해 주세요.",
       );
-      Alert.alert("오류", String(msg));
+      Alert.alert("오류", String(message));
     },
   });
 
   const isAuthBusy = logoutMutation.isPending || withdrawMutation.isPending;
+  const isPushBusy = pushToggleBusy || pushSettingsLoading;
+
+  const openNotionLink = useCallback((url, labelForEmpty) => {
+    const trimmed = String(url ?? "").trim();
+    if (!trimmed) {
+      Alert.alert(
+        "안내",
+        `${labelForEmpty} 노션 링크가 비어 있습니다. 이 파일 상단의 NOTION_URLS 객체에 해당 필드(notice / faq / termsOfService / privacyPolicy)에 URL을 넣어 주세요.`,
+      );
+      return;
+    }
+    Linking.openURL(trimmed).catch(() => {
+      Alert.alert("오류", "링크를 열 수 없습니다.");
+    });
+  }, []);
+
+  const showPermissionSettingsAlert = useCallback(() => {
+    Alert.alert(
+      "알림 허용",
+      Platform.select({
+        ios: "설정 > 알림에서 이 앱의 알림을 허용해 주세요.",
+        default: "설정에서 이 앱의 알림 권한을 허용해 주세요.",
+      }),
+      [
+        { text: "확인", style: "cancel" },
+        { text: "설정", onPress: () => Linking.openSettings() },
+      ],
+    );
+  }, []);
+
+  const onPushSwitchChange = useCallback(
+    async (nextOn) => {
+      if (isPushBusy) {
+        return;
+      }
+
+      setPushToggleBusy(true);
+      try {
+        const result = await submitPushEnabledToServer(nextOn);
+
+        if (result.skipped) {
+          if (result.reason === "NOTIFICATION_PERMISSION_NOT_GRANTED") {
+            if (result.shouldOpenSettings) {
+              showPermissionSettingsAlert();
+            }
+            return;
+          }
+
+          if (result.reason === "NO_ACCESS_TOKEN") {
+            Alert.alert("안내", "로그인이 필요합니다.");
+            return;
+          }
+
+          if (result.reason === "FCM_TOKEN_ERROR") {
+            const hint =
+              result.error?.message ?? result.error?.nativeErrorMessage ?? "";
+            const apsHint =
+              Platform.OS === "ios" &&
+              String(hint).includes("aps-environment")
+                ? "\n\n(iOS) Apple 푸시(APS) 인타이틀먼트가 빌드에 포함되어야 합니다. app.config에 aps-environment를 넣은 뒤 prebuild·재빌드하고, Apple Developer에서 해당 앱 ID에 Push Notifications 기능이 켜져 있는지 확인하세요. 백엔드 문제가 아닙니다."
+                : "";
+
+            Alert.alert(
+              "알림",
+              hint
+                ? `푸시 알림을 변경하는 중 오류가 났습니다.\n${hint}${apsHint}`
+                : "푸시 알림을 변경하는 중 오류가 났습니다. 잠시 후 다시 시도해 주세요.",
+            );
+            return;
+          }
+
+          Alert.alert(
+            "안내",
+            "푸시 알림을 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+          );
+          return;
+        }
+
+        setPushSettings(result.settings ?? EMPTY_PUSH_SETTINGS);
+      } catch (error) {
+        logAxiosError("pushSettingsToggle", error);
+        Alert.alert(
+          "오류",
+          getApiErrorUserMessage(error, "푸시 설정을 변경하지 못했습니다."),
+        );
+        await refreshPushSettings();
+      } finally {
+        setPushToggleBusy(false);
+      }
+    },
+    [isPushBusy, refreshPushSettings, showPermissionSettingsAlert],
+  );
+
+  const onPushDetailChange = useCallback(
+    async (field, nextValue) => {
+      if (isPushBusy) {
+        return;
+      }
+
+      const nextSettings = {
+        ...pushSettings,
+        [field]: nextValue,
+      };
+
+      setPushToggleBusy(true);
+      try {
+        const result = await submitPushDetailSettingsToServer({
+          postCommentPushEnabled: nextSettings.postCommentPushEnabled,
+          postEmotionPushEnabled: nextSettings.postEmotionPushEnabled,
+        });
+
+        if (result.skipped) {
+          if (result.reason === "NO_ACCESS_TOKEN") {
+            Alert.alert("안내", "로그인이 필요합니다.");
+            return;
+          }
+
+          Alert.alert(
+            "안내",
+            "푸시 세부 설정을 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+          );
+          return;
+        }
+
+        setPushSettings(result.settings ?? EMPTY_PUSH_SETTINGS);
+      } catch (error) {
+        logAxiosError("pushDetailSettingsToggle", error);
+        Alert.alert(
+          "오류",
+          getApiErrorUserMessage(
+            error,
+            "푸시 세부 설정을 변경하지 못했습니다.",
+          ),
+        );
+        await refreshPushSettings();
+      } finally {
+        setPushToggleBusy(false);
+      }
+    },
+    [isPushBusy, pushSettings, refreshPushSettings],
+  );
 
   const renderConfirmModal = ({
     visible,
@@ -173,25 +422,65 @@ const ProfileSettingScreen = () => {
         <AppText
           variant="semi18"
           className="text-white"
-          style={{ lineHeight: 24.5 }}
+          style={styles.sectionTitle}
+        >
+          푸시 알림 설정
+        </AppText>
+
+        <View style={styles.pushCard}>
+          {pushSettingsLoading ? (
+            <View style={styles.pushLoadingWrap}>
+              <ActivityIndicator color="#FFF" />
+            </View>
+          ) : (
+            <>
+              <PushSettingRow
+                title="푸시 알람 전체"
+                description="알림을 끄면 모든 소식을 받을 수 없어요."
+                value={pushSettings.pushEnabled}
+                onValueChange={onPushSwitchChange}
+                busy={isPushBusy}
+              />
+              <PushSettingRow
+                title="댓글 알림"
+                value={pushSettings.postCommentPushEnabled}
+                onValueChange={(value) =>
+                  onPushDetailChange("postCommentPushEnabled", value)
+                }
+                busy={isPushBusy}
+              />
+              <PushSettingRow
+                title="공감 알림"
+                value={pushSettings.postEmotionPushEnabled}
+                onValueChange={(value) =>
+                  onPushDetailChange("postEmotionPushEnabled", value)
+                }
+                busy={isPushBusy}
+                showDivider={false}
+              />
+            </>
+          )}
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <AppText
+          variant="semi18"
+          className="text-white"
+          style={styles.sectionTitle}
         >
           계정
         </AppText>
-
         <Pressable
           onPress={() => setLogoutModalVisible(true)}
           disabled={isAuthBusy}
           style={({ pressed }) => [
-            styles.rowPressable,
+            styles.accountRow,
             pressed && styles.rowPressed,
             isAuthBusy && styles.rowDisabled,
           ]}
         >
-          <AppText
-            variant="bodyMedium"
-            className="text-gray-400"
-            style={{ lineHeight: 21.8 }}
-          >
+          <AppText variant="bodyMedium" style={styles.menuItemText}>
             로그아웃
           </AppText>
         </Pressable>
@@ -200,16 +489,12 @@ const ProfileSettingScreen = () => {
           onPress={() => setWithdrawModalVisible(true)}
           disabled={isAuthBusy}
           style={({ pressed }) => [
-            styles.rowPressable,
+            styles.accountRow,
             pressed && styles.rowPressed,
             isAuthBusy && styles.rowDisabled,
           ]}
         >
-          <AppText
-            variant="bodyMedium"
-            className="text-gray-400"
-            style={{ lineHeight: 21.8 }}
-          >
+          <AppText variant="bodyMedium" style={styles.menuItemText}>
             계정 탈퇴
           </AppText>
         </Pressable>
@@ -219,20 +504,81 @@ const ProfileSettingScreen = () => {
         <AppText
           variant="semi18"
           className="text-white"
-          style={{ lineHeight: 24.5 }}
+          style={styles.sectionTitle}
         >
           안내
         </AppText>
+        <Pressable
+          onPress={() => openNotionLink(NOTION_URLS.notice, "공지사항")}
+          style={({ pressed }) => [
+            styles.linkRow,
+            pressed && styles.rowPressed,
+          ]}
+        >
+          <AppText variant="bodyMedium" style={styles.linkRowText}>
+            공지사항
+          </AppText>
+          <MoreArrow width={22} height={22} />
+        </Pressable>
+        <Pressable
+          onPress={() => openNotionLink(NOTION_URLS.faq, "FAQ")}
+          style={({ pressed }) => [
+            styles.linkRow,
+            pressed && styles.rowPressed,
+          ]}
+        >
+          <AppText variant="bodyMedium" style={styles.linkRowText}>
+            FAQ
+          </AppText>
+          <MoreArrow width={22} height={22} />
+        </Pressable>
       </View>
 
       <View style={styles.section}>
         <AppText
           variant="semi18"
           className="text-white"
-          style={{ lineHeight: 24.5 }}
+          style={styles.sectionTitle}
         >
           서비스 정보
         </AppText>
+        <Pressable
+          onPress={() =>
+            openNotionLink(NOTION_URLS.termsOfService, "서비스 이용약관")
+          }
+          style={({ pressed }) => [
+            styles.linkRow,
+            pressed && styles.rowPressed,
+          ]}
+        >
+          <AppText variant="bodyMedium" style={styles.linkRowText}>
+            서비스 이용약관
+          </AppText>
+          <MoreArrow width={22} height={22} />
+        </Pressable>
+        <Pressable
+          onPress={() =>
+            openNotionLink(NOTION_URLS.privacyPolicy, "개인정보 처리방침")
+          }
+          style={({ pressed }) => [
+            styles.linkRow,
+            pressed && styles.rowPressed,
+          ]}
+        >
+          <AppText variant="bodyMedium" style={styles.linkRowText}>
+            개인정보 처리방침
+          </AppText>
+          <MoreArrow width={22} height={22} />
+        </Pressable>
+
+        <View style={styles.versionRow}>
+          <AppText variant="bodyMedium" style={styles.linkRowText}>
+            현재버전
+          </AppText>
+          <AppText variant="smallRegular" style={styles.versionMeta}>
+            V.{APP_VERSION} 최신버전
+          </AppText>
+        </View>
       </View>
 
       {renderConfirmModal({
@@ -268,12 +614,111 @@ const styles = StyleSheet.create({
     backgroundColor: "#121212",
   },
   section: {
-    marginVertical: 25,
+    marginVertical: 20,
     marginHorizontal: 25,
     gap: 13,
   },
-  rowPressable: {
-    alignSelf: "flex-start",
+  sectionTitle: {
+    lineHeight: 24.5,
+    marginBottom: 4,
+  },
+  pushCard: {
+    borderRadius: 10,
+    backgroundColor: "rgba(255,255,255,0.06)",
+    overflow: "hidden",
+  },
+  pushLoadingWrap: {
+    minHeight: 164,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  pushItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    minHeight: 58,
+  },
+  pushItemDivider: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(255,255,255,0.08)",
+  },
+  pushItemTextWrap: {
+    flex: 1,
+    marginRight: 12,
+  },
+  pushItemTitle: {
+    color: "#FFFFFF",
+    lineHeight: 22,
+  },
+  pushItemDescription: {
+    color: "rgba(228, 228, 228, 0.50)",
+    marginTop: 2,
+    lineHeight: 17,
+  },
+  pushToggleTrack: {
+    width: PUSH_TOGGLE_W,
+    height: PUSH_TOGGLE_H,
+    borderRadius: PUSH_TOGGLE_H / 2,
+    padding: PUSH_TOGGLE_PAD,
+    justifyContent: "center",
+  },
+  pushToggleTrackOff: {
+    backgroundColor: "rgba(172, 172, 172, 0.20)",
+  },
+  pushToggleTrackOn: {
+    backgroundColor: "#34C759",
+  },
+  pushToggleInner: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  pushToggleThumb: {
+    width: PUSH_TOGGLE_THUMB,
+    height: PUSH_TOGGLE_THUMB,
+    borderRadius: PUSH_TOGGLE_THUMB / 2,
+    backgroundColor: "#FFFFFF",
+  },
+  accountRow: {
+    alignSelf: "stretch",
+    minHeight: 44,
+    paddingVertical: 4,
+    justifyContent: "center",
+  },
+  menuItemText: {
+    lineHeight: 21.8,
+    color: "rgba(228, 228, 228, 0.50)",
+  },
+  linkRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    alignSelf: "stretch",
+    width: "100%",
+    minHeight: 44,
+    paddingVertical: 4,
+  },
+  linkRowText: {
+    flex: 1,
+    marginRight: 12,
+    lineHeight: 21.8,
+    color: "rgba(228, 228, 228, 0.50)",
+  },
+  versionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    alignSelf: "stretch",
+    width: "100%",
+    minHeight: 44,
+    paddingVertical: 4,
+  },
+  versionMeta: {
+    flexShrink: 0,
+    lineHeight: 13.6,
+    color: "rgba(228, 228, 228, 0.45)",
   },
   rowPressed: {
     opacity: 0.7,

--- a/src/features/profile/screens/Setting/ProfileSettingScreen.jsx
+++ b/src/features/profile/screens/Setting/ProfileSettingScreen.jsx
@@ -363,97 +363,6 @@ const ProfileSettingScreen = () => {
     [isPushBusy, pushSettings, refreshPushSettings],
   );
 
-  const openNotionLink = useCallback((url, labelForEmpty) => {
-    const trimmed = String(url ?? "").trim();
-    if (!trimmed) {
-      Alert.alert(
-        "안내",
-        `${labelForEmpty} 노션 링크가 비어 있습니다. 이 파일 상단의 NOTION_URLS 객체에 해당 필드(notice / faq / termsOfService / privacyPolicy)에 URL을 넣어 주세요.`,
-      );
-      return;
-    }
-    Linking.openURL(trimmed).catch(() => {
-      Alert.alert("오류", "링크를 열 수 없습니다.");
-    });
-  }, []);
-
-  const onPushSwitchChange = useCallback(
-    async (nextOn) => {
-      if (pushToggleBusy) return;
-      setPushToggleBusy(true);
-      try {
-        if (nextOn) {
-          const result = await submitPushEnabledToServer(true);
-          if (result.skipped) {
-            if (result.reason === "NOTIFICATION_PERMISSION_NOT_GRANTED") {
-              Alert.alert(
-                "알림 허용",
-                Platform.select({
-                  ios: "설정 > 알림에서 이 앱의 알림을 허용해 주세요.",
-                  default: "설정에서 이 앱의 알림 권한을 허용해 주세요.",
-                }),
-                [
-                  { text: "확인", style: "cancel" },
-                  { text: "설정", onPress: () => Linking.openSettings() },
-                ],
-              );
-              await refreshPushSwitchFromOs();
-              return;
-            }
-            if (result.reason === "NO_ACCESS_TOKEN") {
-              Alert.alert("안내", "로그인이 필요합니다.");
-              await refreshPushSwitchFromOs();
-              return;
-            }
-            if (result.reason === "FCM_TOKEN_ERROR") {
-              const hint =
-                result.error?.message ?? result.error?.nativeErrorMessage ?? "";
-              const apsHint =
-                Platform.OS === "ios" &&
-                String(hint).includes("aps-environment")
-                  ? "\n\n(iOS) Apple 푸시(APS) 인타이틀먼트가 빌드에 포함되어야 합니다. app.config에 aps-environment를 넣은 뒤 prebuild·재빌드하고, Apple Developer에서 해당 앱 ID에 Push Notifications 기능이 켜져 있는지 확인하세요. 백엔드 문제가 아닙니다."
-                  : "";
-              Alert.alert(
-                "알림",
-                hint
-                  ? `푸시 알림을 다시 켜는 중 오류가 났습니다.\n${hint}${apsHint}`
-                  : "푸시 알림을 다시 켜는 중 오류가 났습니다. 잠시 후 다시 시도하거나 앱을 다시 시작해 주세요.",
-              );
-              await refreshPushSwitchFromOs();
-              return;
-            }
-            Alert.alert(
-              "안내",
-              "푸시 알림을 켤 수 없습니다. 잠시 후 다시 시도해 주세요.",
-            );
-            await refreshPushSwitchFromOs();
-            return;
-          }
-          lastServerPushEnabledRef.current = true;
-          setPushSwitchOn(true);
-        } else {
-          const result = await submitPushEnabledToServer(false);
-          if (result.skipped && result.reason === "NO_ACCESS_TOKEN") {
-            Alert.alert("안내", "로그인이 필요합니다.");
-          } else {
-            lastServerPushEnabledRef.current = false;
-            setPushSwitchOn(false);
-          }
-        }
-      } catch (e) {
-        logAxiosError("pushSettingsToggle", e);
-        Alert.alert(
-          "오류",
-          getApiErrorUserMessage(e, "푸시 설정을 변경하지 못했습니다."),
-        );
-        await refreshPushSwitchFromOs();
-      } finally {
-        setPushToggleBusy(false);
-      }
-    },
-    [pushToggleBusy, refreshPushSwitchFromOs],
-  );
-
   const renderConfirmModal = ({
     visible,
     onClose,
@@ -509,27 +418,6 @@ const ProfileSettingScreen = () => {
   return (
     <SafeAreaView style={styles.safeArea}>
       <AppHeader pageName="설정" showBack />
-
-      <View style={styles.section}>
-        <View style={styles.pushRow}>
-          <AppText
-            variant="semi18"
-            className="text-white"
-            style={styles.pushLabel}
-          >
-            푸시 알람 설정
-          </AppText>
-          {pushToggleBusy ? (
-            <ActivityIndicator color="#FFF" />
-          ) : (
-            <PushSettingToggle
-              value={pushSwitchOn}
-              onValueChange={onPushSwitchChange}
-              busy={pushToggleBusy}
-            />
-          )}
-        </View>
-      </View>
 
       <View style={styles.section}>
         <AppText

--- a/src/shared/component/PushDeviceBootstrap.jsx
+++ b/src/shared/component/PushDeviceBootstrap.jsx
@@ -23,7 +23,7 @@ const PushDeviceBootstrap = () => {
 
     syncedTokenRef.current = accessToken;
 
-    syncCurrentDevicePushSettings({ requestPermission: true }).catch((error) => {
+    syncCurrentDevicePushSettings({ requestPermission: false }).catch((error) => {
       console.warn("[푸시] 로그인 후 디바이스 푸시 설정 동기화에 실패했습니다.", error);
     });
   }, [accessToken]);

--- a/src/shared/services/pushDeviceService.js
+++ b/src/shared/services/pushDeviceService.js
@@ -156,11 +156,6 @@ async function ensureNotificationPermissionForEnable() {
   };
 }
 
-/** OS 알림 권한 허용 여부 (설정 화면 토글 표시용) */
-export async function getNotificationPermissionGranted() {
-  return ensureNotificationPermission({ requestPermission: false });
-}
-
 async function getFcmToken() {
   if (Platform.OS === "ios") {
     await messaging().registerDeviceForRemoteMessages();

--- a/src/shared/services/pushDeviceService.js
+++ b/src/shared/services/pushDeviceService.js
@@ -19,6 +19,21 @@ const isAuthorizedStatus = (status) =>
 const getErrorMessage = (error) =>
   error?.message ?? error?.nativeErrorMessage ?? String(error ?? "");
 
+const normalizePushSettings = (settings) => {
+  const postCommentPushEnabled = Boolean(settings?.postCommentPushEnabled);
+  const postEmotionPushEnabled = Boolean(settings?.postEmotionPushEnabled);
+
+  return {
+    deviceId: settings?.deviceId ?? null,
+    pushEnabled:
+      typeof settings?.pushEnabled === "boolean"
+        ? settings.pushEnabled
+        : postCommentPushEnabled && postEmotionPushEnabled,
+    postCommentPushEnabled,
+    postEmotionPushEnabled,
+  };
+};
+
 async function getAccessToken() {
   const storeToken = useUserStore.getState().accessToken;
 
@@ -29,43 +44,116 @@ async function getAccessToken() {
   return SecureStore.getItemAsync("accessToken");
 }
 
-async function ensureAndroidNotificationPermission({ requestPermission }) {
-  if (!isAndroid13OrAbove()) {
-    return true;
+async function getAndroidNotificationPermissionStatus() {
+  if (!isAndroid13OrAbove() || !ANDROID_NOTIFICATION_PERMISSION) {
+    return {
+      granted: true,
+      canRequest: false,
+      status: "AUTHORIZED",
+    };
   }
 
-  if (!ANDROID_NOTIFICATION_PERMISSION) {
-    return true;
-  }
+  const granted = await PermissionsAndroid.check(ANDROID_NOTIFICATION_PERMISSION);
 
-  if (requestPermission) {
-    const result = await PermissionsAndroid.request(
-      ANDROID_NOTIFICATION_PERMISSION,
-    );
-    return result === PermissionsAndroid.RESULTS.GRANTED;
-  }
-
-  return PermissionsAndroid.check(ANDROID_NOTIFICATION_PERMISSION);
+  return {
+    granted,
+    canRequest: !granted,
+    status: granted ? "AUTHORIZED" : "DENIED",
+  };
 }
 
-async function ensureIosNotificationPermission({ requestPermission }) {
-  const status = requestPermission
-    ? await messaging().requestPermission()
-    : await messaging().hasPermission();
+async function requestAndroidNotificationPermission() {
+  if (!isAndroid13OrAbove() || !ANDROID_NOTIFICATION_PERMISSION) {
+    return {
+      granted: true,
+      status: "AUTHORIZED",
+    };
+  }
 
-  return isAuthorizedStatus(status);
+  const result = await PermissionsAndroid.request(
+    ANDROID_NOTIFICATION_PERMISSION,
+  );
+
+  return {
+    granted: result === PermissionsAndroid.RESULTS.GRANTED,
+    status: result,
+  };
 }
 
-async function ensureNotificationPermission({ requestPermission }) {
+async function getIosNotificationPermissionStatus() {
+  const status = await messaging().hasPermission();
+
+  return {
+    granted: isAuthorizedStatus(status),
+    canRequest: status === messaging.AuthorizationStatus.NOT_DETERMINED,
+    status,
+  };
+}
+
+async function requestIosNotificationPermission() {
+  const status = await messaging().requestPermission();
+
+  return {
+    granted: isAuthorizedStatus(status),
+    status,
+  };
+}
+
+export async function getNotificationPermissionStatus() {
   if (Platform.OS === "ios") {
-    return ensureIosNotificationPermission({ requestPermission });
+    return getIosNotificationPermissionStatus();
   }
 
   if (Platform.OS === "android") {
-    return ensureAndroidNotificationPermission({ requestPermission });
+    return getAndroidNotificationPermissionStatus();
   }
 
-  return false;
+  return {
+    granted: false,
+    canRequest: false,
+    status: "UNSUPPORTED",
+  };
+}
+
+/** OS 알림 권한 허용 여부 (설정 화면/온보딩 판단용) */
+export async function getNotificationPermissionGranted() {
+  const permissionStatus = await getNotificationPermissionStatus();
+  return permissionStatus.granted;
+}
+
+async function ensureNotificationPermissionForEnable() {
+  const currentStatus = await getNotificationPermissionStatus();
+
+  if (currentStatus.granted) {
+    return {
+      granted: true,
+      requested: false,
+      status: currentStatus.status,
+    };
+  }
+
+  if (!currentStatus.canRequest) {
+    return {
+      granted: false,
+      requested: false,
+      status: currentStatus.status,
+      shouldOpenSettings: true,
+    };
+  }
+
+  const requestResult =
+    Platform.OS === "ios"
+      ? await requestIosNotificationPermission()
+      : await requestAndroidNotificationPermission();
+
+  const nextStatus = await getNotificationPermissionStatus();
+
+  return {
+    granted: requestResult.granted,
+    requested: true,
+    status: nextStatus.status,
+    shouldOpenSettings: !requestResult.granted && !nextStatus.canRequest,
+  };
 }
 
 async function getFcmToken() {
@@ -74,6 +162,254 @@ async function getFcmToken() {
   }
 
   return messaging().getToken();
+}
+
+async function obtainFcmTokenReliable() {
+  const readNonEmpty = async () => {
+    const token = await getFcmToken();
+    const normalizedToken = token && String(token).trim();
+
+    if (!normalizedToken) {
+      throw new Error("FCM token is empty");
+    }
+
+    return normalizedToken;
+  };
+
+  try {
+    return await readNonEmpty();
+  } catch (firstError) {
+    try {
+      await messaging().deleteToken();
+    } catch {
+      /* ignore */
+    }
+
+    try {
+      return await readNonEmpty();
+    } catch {
+      throw firstError;
+    }
+  }
+}
+
+async function patchDevicePushEnabled(accessToken, deviceId, pushEnabled) {
+  const { data } = await api.patch(
+    "/api/v1/devices/push-enabled",
+    { deviceId, pushEnabled },
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+
+  if (data && data.success === false) {
+    const error = new Error(data.message || "push-enabled rejected");
+    error.apiPayload = data;
+    throw error;
+  }
+
+  return data;
+}
+
+async function patchDevicePushDetailSettings(
+  accessToken,
+  deviceId,
+  postCommentPushEnabled,
+  postEmotionPushEnabled,
+) {
+  const { data } = await api.patch(
+    "/api/v1/devices/push-detail-settings",
+    {
+      deviceId,
+      postCommentPushEnabled,
+      postEmotionPushEnabled,
+    },
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+
+  if (data && data.success === false) {
+    const error = new Error(data.message || "push-detail-settings rejected");
+    error.apiPayload = data;
+    throw error;
+  }
+
+  return data;
+}
+
+async function putDevicePushSettings(accessToken, deviceId, fcmToken) {
+  const { data } = await api.put(
+    "/api/v1/devices/push-settings",
+    {
+      deviceId,
+      fcmToken: fcmToken ?? "",
+    },
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+
+  if (data && data.success === false) {
+    const error = new Error(data.message || "push-settings rejected");
+    error.apiPayload = data;
+    throw error;
+  }
+
+  return data;
+}
+
+async function getDevicePushSettings(accessToken, deviceId) {
+  const { data } = await api.get("/api/v1/devices/push-settings", {
+    params: { deviceId },
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  return normalizePushSettings(data);
+}
+
+export async function submitPushEnabledToServer(pushEnabled) {
+  const accessToken = await getAccessToken();
+  if (!accessToken) {
+    return { skipped: true, reason: "NO_ACCESS_TOKEN" };
+  }
+
+  const deviceId = await getDeviceId();
+
+  if (!pushEnabled) {
+    await patchDevicePushEnabled(accessToken, deviceId, false);
+    return {
+      ok: true,
+      settings: normalizePushSettings({
+        deviceId,
+        pushEnabled: false,
+        postCommentPushEnabled: false,
+        postEmotionPushEnabled: false,
+      }),
+    };
+  }
+
+  const permissionResult = await ensureNotificationPermissionForEnable();
+  if (!permissionResult.granted) {
+    return {
+      skipped: true,
+      reason: "NOTIFICATION_PERMISSION_NOT_GRANTED",
+      shouldOpenSettings: permissionResult.shouldOpenSettings === true,
+      permissionStatus: permissionResult.status,
+    };
+  }
+
+  await patchDevicePushEnabled(accessToken, deviceId, true);
+
+  let fcmToken = null;
+  let tokenSync = null;
+  try {
+    fcmToken = await obtainFcmTokenReliable();
+    await putDevicePushSettings(accessToken, deviceId, fcmToken);
+    tokenSync = { ok: true };
+  } catch (error) {
+    tokenSync = { skipped: true, reason: "FCM_TOKEN_ERROR", error };
+  }
+
+  return {
+    ok: true,
+    fcmToken,
+    tokenSync,
+    settings: normalizePushSettings({
+      deviceId,
+      pushEnabled: true,
+      postCommentPushEnabled: true,
+      postEmotionPushEnabled: true,
+    }),
+  };
+}
+
+export async function submitPushDetailSettingsToServer({
+  postCommentPushEnabled,
+  postEmotionPushEnabled,
+}) {
+  const accessToken = await getAccessToken();
+  if (!accessToken) {
+    return { skipped: true, reason: "NO_ACCESS_TOKEN" };
+  }
+
+  const deviceId = await getDeviceId();
+
+  await patchDevicePushDetailSettings(
+    accessToken,
+    deviceId,
+    postCommentPushEnabled,
+    postEmotionPushEnabled,
+  );
+
+  return {
+    ok: true,
+    settings: normalizePushSettings({
+      deviceId,
+      pushEnabled: postCommentPushEnabled && postEmotionPushEnabled,
+      postCommentPushEnabled,
+      postEmotionPushEnabled,
+    }),
+  };
+}
+
+export async function fetchCurrentDevicePushSettings() {
+  const accessToken = await getAccessToken();
+  const deviceId = await getDeviceId();
+
+  if (!accessToken) {
+    return {
+      skipped: true,
+      reason: "NO_ACCESS_TOKEN",
+      settings: normalizePushSettings({ deviceId }),
+    };
+  }
+
+  try {
+    const settings = await getDevicePushSettings(accessToken, deviceId);
+    return { ok: true, settings };
+  } catch (error) {
+    if (error?.response?.status === 404) {
+      return {
+        skipped: true,
+        reason: "DEVICE_NOT_FOUND",
+        settings: normalizePushSettings({ deviceId }),
+      };
+    }
+
+    throw error;
+  }
+}
+
+export async function runSignupPushPermissionFlow() {
+  const permissionResult = await ensureNotificationPermissionForEnable();
+  if (!permissionResult.granted) {
+    return {
+      skipped: true,
+      reason: "NOTIFICATION_PERMISSION_NOT_GRANTED",
+      shouldOpenSettings: permissionResult.shouldOpenSettings === true,
+      permissionStatus: permissionResult.status,
+    };
+  }
+
+  const accessToken = await getAccessToken();
+  const deviceId = await getDeviceId();
+
+  if (!accessToken) {
+    return { skipped: true, reason: "NO_ACCESS_TOKEN" };
+  }
+
+  await patchDevicePushEnabled(accessToken, deviceId, true);
+
+  const syncResult = await syncCurrentDevicePushSettings({
+    requestPermission: false,
+  });
+
+  return {
+    ok: true,
+    fcmToken: syncResult.skipped ? null : syncResult.fcmToken,
+    tokenSync: syncResult.skipped ? syncResult : { ok: true },
+    settings: normalizePushSettings({
+      deviceId,
+      pushEnabled: true,
+      postCommentPushEnabled: true,
+      postEmotionPushEnabled: true,
+    }),
+  };
 }
 
 export async function syncCurrentDevicePushSettings({
@@ -87,23 +423,20 @@ export async function syncCurrentDevicePushSettings({
   }
 
   const deviceId = await getDeviceId();
-  const hasPermission = await ensureNotificationPermission({ requestPermission });
+  const hasPermission = requestPermission
+    ? (await ensureNotificationPermissionForEnable()).granted
+    : await getNotificationPermissionGranted();
 
   let fcmToken = null;
-  let pushEnabled = false;
   let skippedReason = null;
 
   if (hasPermission) {
     try {
       fcmToken = overrideFcmToken ?? (await getFcmToken());
-      pushEnabled = Boolean(fcmToken);
     } catch (error) {
       const errorMessage = getErrorMessage(error);
 
-      if (
-        Platform.OS === "ios" &&
-        errorMessage.includes("aps-environment")
-      ) {
+      if (Platform.OS === "ios" && errorMessage.includes("aps-environment")) {
         skippedReason = "MISSING_APNS_ENTITLEMENT";
         console.warn(
           "[푸시] iOS 푸시 entitlement가 없어 FCM 토큰을 발급할 수 없습니다.",
@@ -122,28 +455,14 @@ export async function syncCurrentDevicePushSettings({
       skipped: true,
       reason: skippedReason ?? "FCM_TOKEN_UNAVAILABLE",
       deviceId,
-      pushEnabled: false,
     };
   }
 
-  await api.put(
-    "/api/v1/devices/push-settings",
-    {
-      deviceId,
-      fcmToken,
-      pushEnabled,
-    },
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    },
-  );
+  await putDevicePushSettings(accessToken, deviceId, fcmToken);
 
   return {
     deviceId,
     fcmToken,
-    pushEnabled,
   };
 }
 


### PR DESCRIPTION
## PR Title
- 회원가입 후 푸시 권한 요청 및 디바이스 푸시 설정 플로우 구현, 전체 게시판 글쓰기 분기 수정

## What (작업 내용)
- 회원가입 완료 직후 푸시 권한 요청용 프리퍼미션 바텀시트를 추가했습니다.
- 회원가입 완료 응답의 최종 accessToken / refreshToken 저장 로직을 반영해 이후 요청이 최신 토큰 기준으로 동작하도록 수정했습니다.
- 로그인 직후 자동 권한 요청은 제거하고, 디바이스 푸시 토큰 동기화만 수행하도록 변경했습니다.
- 백엔드 스펙에 맞춰 디바이스 푸시 설정 API를 조회 / 전체 토글 / 세부 토글 기준으로 분리하고 설정 화면과 연동했습니다.
- 전체 게시판에서 글쓰기 진입 시 작성 화면의 초기 게시판 선택값이 ALL을 따르도록 수정했습니다.

## Key Points (중점 사항)
### 회원가입 이후 푸시 권한 요청 시점 조정
- 기존에는 로그인 직후 푸시 권한 요청이 함께 동작했는데,
   이를 회원가입 완료 직후로 옮기고 프리퍼미션 바텀시트를 통해 먼저 안내한 뒤 요청하도록 변경했습니다.

### 회원가입 완료 후 최종 토큰 반영
- 회원가입 완료 응답에서 내려오는 최종 accessToken / refreshToken을 즉시 저장하도록 수정했습니다.
- 회원가입 직후에도 최신 인증 상태를 기준으로 커뮤니티 등 후속 API 요청이 정상 동작하도록 보완했습니다.

### 디바이스 푸시 설정 연동 방식 정리
- 앱 내부 푸시 설정과 OS 알림 권한을 분리해서 다루도록 수정했습니다.
- 설정 화면에서는 서버에 저장된 디바이스 푸시 설정값을 기준으로 전체 / 댓글 / 공감 토글 상태를 조회하고 변경할 수 있도록 연동했습니다.

### 전체 게시판 글쓰기 진입 문맥 반영
- 전체 게시판에서 글쓰기 화면으로 들어가도 기본 게시판 값이 팀 게시판으로 잡히던 문제를 수정했습니다.

## Additional Notes (기타 참고사항)
- iOS 알림 권한은 최초 허용/거절 이후 앱에서 다시 시스템 팝업을 띄울 수 없으므로, 이후 변경은 기기 설정에서 직접 해야 합니다.